### PR TITLE
Revert "LOOC Is Now Admin-Visible"

### DIFF
--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -63,8 +63,6 @@
 	else
 		prefix = "LOOC (WP)"
 
-	var/our_message = "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>"
-	message_admins("[prefix]: [ADMIN_LOOKUPFLW(src)] [msg]")
 	for(var/mob/M in range(7,src))
 		var/client/C = M.client
 		if(!M.client)
@@ -76,5 +74,5 @@
 				var/turf/speakturf = get_turf(M)
 				var/turf/sourceturf = get_turf(usr)
 				if((speakturf in get_hear(7, sourceturf)) || wp == 1)
-					to_chat(C, our_message)
-	to_chat(usr, our_message)
+					to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>")
+	to_chat(usr, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>")


### PR DESCRIPTION
Reverts NovaSector/Solaris#47

TL;DR - In-game this was found to be super distracting without the luxury of chat tabs. Additionally the lookup verbs weren't working, and I just...
Nah. Not right now. When we get /tg/chat? Hell Yeah. Not now.