### PR TITLE
Reverts Pilgrim Round Start and Adds Outlander Virtue

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
@@ -3,8 +3,8 @@
 	flag = PILGRIM
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 0
-	spawn_positions = 0 //disables round-start spawn of pilgrims but allows migrant waves
+	total_positions = 20
+	spawn_positions = 15 //No longer disables pilgrim roundstart spawn, but does limit it (not that we'll ever reach the pop for it to matter)
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Fleeing misfortune you head your way towards Sunmarch. You're not a soldier or an explorer, but a humble migrant trying to look for a better life - if you get to survive the trip that is."
 

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -24,8 +24,7 @@
 	round_contrib_points = 3
 
 	//No nobility for you, being a member of the clergy means you gave UP your nobility. It says this in many of the church tutorial texts.
-	virtue_restrictions = list(/datum/virtue/utility/noble)
-	virtue_restrictions = list(/datum/virtue/utility/outlander) //Local priests probably shouldn't be from Not Here, though monks and the like make sense.
+	virtue_restrictions = list(/datum/virtue/utility/noble, /datum/virtue/utility/outlander) //Local priests probably shouldn't be from Not Here, though monks and the like make sense.
 
 /datum/outfit/job/roguetown/priest/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -25,6 +25,7 @@
 
 	//No nobility for you, being a member of the clergy means you gave UP your nobility. It says this in many of the church tutorial texts.
 	virtue_restrictions = list(/datum/virtue/utility/noble)
+	virtue_restrictions = list(/datum/virtue/utility/outlander) //Local priests probably shouldn't be from Not Here, though monks and the like make sense.
 
 /datum/outfit/job/roguetown/priest/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -18,6 +18,7 @@
 	round_contrib_points = 2
 
 	cmode_music = 'sound/music/combat_guard2.ogg'
+	virtue_restrictions = list(/datum/virtue/utility/outlander)//trusted guard of the Marquis should *probably* not be a traveller from a foreign land
 
 /datum/job/roguetown/gatemaster/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -21,6 +21,7 @@
 	max_pq = null
 	cmode_music = 'sound/music/combat_guard2.ogg'
 
+	virtue_restrictions = list(/datum/virtue/utility/outlander)//Command roles probably shouldn't be from Not Here
 
 
 /datum/job/roguetown/sergeant/after_spawn(mob/living/L, mob/M, latejoin = TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -19,6 +19,7 @@
 	round_contrib_points = 3
 
 	cmode_music = 'sound/music/combat_bog.ogg'
+	virtue_restrictions = list(/datum/virtue/utility/outlander)//Village elder probably shouldn't be from Not Here
 
 /datum/job/roguetown/woodsman/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -22,6 +22,7 @@
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_guard.ogg'
 	advclass_cat_rolls = list (CTAG_MARSHAL = 20)
+	virtue_restrictions = list(/datum/virtue/utility/outlander)//Command roles probably shouldn't be from Not Here
 
 /datum/outfit/job/roguetown/marshal/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -23,7 +23,8 @@
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_knight.ogg'
-
+	virtue_restrictions = list(/datum/virtue/utility/outlander)//Command roles probably shouldn't be from Not Here
+	
 /datum/outfit/job/roguetown/captain
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	armor = /obj/item/clothing/suit/roguetown/armor/plate

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -19,7 +19,8 @@
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'
-
+	virtue_restrictions = list(/datum/virtue/utility/outlander)//Command roles probably shouldn't be from Not Here
+	
 /*
 /datum/job/roguetown/hand/special_job_check(mob/dead/new_player/player)
 	if(!player)

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -18,6 +18,7 @@
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'
+	virtue_restrictions = list(/datum/virtue/utility/outlander)//Command roles probably shouldn't be from Not Here
 
 /datum/outfit/job/roguetown/steward/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -86,6 +86,17 @@
 					recipient.forceMove(spawn_loc)
 					to_chat(recipient, span_notice("As a resident of Solaris Ridge, you find yourself in the local tavern."))
 
+/datum/virtue/utility/outlander
+	name = "Outlander"
+	desc = "I have travelled far to The Ridge, and the journey has written itself into my body. Anyone who sees me will know I am from elsewhere."
+	custom_text = "Incompatible with the Resident Virtue and certain jobs."
+	added_traits = list(TRAIT_OUTLANDER)
+	added_stashed_items = list("pouch of rations" = /obj/item/storage/belt/rogue/pouch/food)
+	added_skills = list(list(/datum/skill/misc/climbing, 2, 4), //traversal skills because you've travelled here from elsewhere.
+						list(/datum/skill/misc/swimming, 2, 4),
+						list(/datum/skill/misc/athletics, 2, 4),
+	)
+	
 /datum/virtue/utility/failed_squire
 	name = "Failed Squire"
 	desc = "I was once a squire in training, but failed to achieve knighthood. Though my dreams of glory were dashed, I retained my knowledge of equipment maintenance and repair."

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -92,9 +92,9 @@
 	custom_text = "Incompatible with the Resident Virtue and certain jobs."
 	added_traits = list(TRAIT_OUTLANDER)
 	added_stashed_items = list("pouch of rations" = /obj/item/storage/belt/rogue/pouch/food)
-	added_skills = list(list(/datum/skill/misc/climbing, 2, 4), //traversal skills because you've travelled here from elsewhere.
+	added_skills = list(list(/datum/skill/misc/climbing, 2, 3), //traversal skills because you've travelled here from elsewhere.
 						list(/datum/skill/misc/swimming, 2, 4),
-						list(/datum/skill/misc/athletics, 2, 4),
+						list(/datum/skill/misc/athletics, 2, 3),
 	)
 	
 /datum/virtue/utility/failed_squire


### PR DESCRIPTION
## About The Pull Request

Allows for Pilgrim Roundstart.

Additionally, adds the Outlander virtue. 

- This virtue marks you as a foreigner, gives you a small pouch of rations, and gives you 2 levels in traversal skills from your long trek to The Ridge. 
- Athletics and climbing are set to not exceed Journeyman, and so are of little value to most combat roles. (Expert is what allows you to climb built walls and that was too much). Swimming can go up to Expert, because it's niche.
- Command Roles are incompatible with the Outlander Virtue for narrative reasons.

## Testing Evidence

![bae5f25964c2af84e12fa970e6437deb](https://github.com/user-attachments/assets/cf8cb75c-6535-46e4-a226-2b3b95f1a030)
![9705ea3eed24ca7564b6c239f38fa0db](https://github.com/user-attachments/assets/1783f34c-0af5-4de1-b3aa-cb75f6243a78)
![72cd3ccb128097e9ed9fba27bde7d028](https://github.com/user-attachments/assets/6ece6c6d-b795-4ad0-bb00-bc3dcdab865a)
![6d6353990b75cf4d05d408807a5e2b62](https://github.com/user-attachments/assets/05485e6e-55b9-460e-8948-7e131139d8d5)



## Why It's Good For The Game

Pilgrim roundstart allows for a variety of roleplaying directions that waiting for waves does not. It allows for group roleplay opportunities, and does no harm to be enabled. 

The Outlander Virtue additionally allows for adding texture to a character's place in the world. The additional traversal skills are, while nice, largely ribbon features to bring it in-line with other virtues. 