### PR TITLE
Altering [POSITIVE] alchemical potions' colours and taste descriptions

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -112,7 +112,7 @@
 	name = "Mana Potion"
 	description = "Gradually regenerates energy."
 	reagent_state = LIQUID
-	color = "#000042"
+	color = "#0000ff"
 	taste_description = "sweet mana"
 	overdose_threshold = 0
 	metabolization_rate = REAGENTS_METABOLISM
@@ -126,7 +126,7 @@
 /datum/reagent/medicine/strongmana
 	name = "Strong Mana Potion"
 	description = "Rapidly regenerates energy."
-	color = "#0000ff"
+	color = "#000080"
 	taste_description = "raw power"
 	metabolization_rate = REAGENTS_METABOLISM * 3
 
@@ -139,7 +139,7 @@
 	name = "Stamina Potion"
 	description = "Gradually regenerates stamina."
 	reagent_state = LIQUID
-	color = "#129c00"
+	color = "#13df00"
 	taste_description = "sweet tea"
 	overdose_threshold = 0
 	metabolization_rate = REAGENTS_METABOLISM
@@ -153,8 +153,8 @@
 /datum/reagent/medicine/strongstam
 	name = "Strong Stamina Potion"
 	description = "Rapidly regenerates stamina."
-	color = "#13df00"
-	taste_description = "sparkly static"
+	color = "#129c00"
+	taste_description = "sparkling static"
 	metabolization_rate = REAGENTS_METABOLISM * 3
 
 /datum/reagent/medicine/strongstam/on_mob_life(mob/living/carbon/M)
@@ -166,8 +166,8 @@
 	name = "Poison Antidote"
 	description = ""
 	reagent_state = LIQUID
-	color = "#00ff00"
-	taste_description = "sickly sweet"
+	color = "#ccccff"
+	taste_description = "cleansing river water"
 	metabolization_rate = REAGENTS_METABOLISM
 
 /datum/reagent/medicine/antidote/on_mob_life(mob/living/carbon/M)
@@ -180,8 +180,8 @@
 	name = "Disease Cure"
 	description = ""
 	reagent_state = LIQUID
-	color = "#004200"
-	taste_description = "dirt"
+	color = "#cc99ff"
+	taste_description = "sweet salvation"
 	metabolization_rate = REAGENTS_METABOLISM * 3
 
 /datum/reagent/medicine/diseasecure/on_mob_life(mob/living/carbon/M)
@@ -198,8 +198,8 @@
 
 /datum/reagent/buff/strength
 	name = "Strength"
-	color = "#ff9000"
-	taste_description = "old meat"
+	color = "#800000"
+	taste_description = "burning fire and invigoration"
 
 /datum/reagent/buff/strength/on_mob_add(mob/living/carbon/M)
 	testing("str pot in system")
@@ -212,8 +212,8 @@
 
 /datum/reagent/buff/perception
 	name = "Perception"
-	color = "#ffff00"
-	taste_description = "cat piss"
+	color = "##ffc34d"
+	taste_description = "a chalky, bitter awareness"
 
 /datum/reagent/buff/perception/on_mob_life(mob/living/carbon/M)
 	testing("per pot in system")
@@ -226,8 +226,8 @@
 
 /datum/reagent/buff/intelligence
 	name = "Intelligence"
-	color = "#438127"
-	taste_description = "bog water"
+	color = "#00b386"
+	taste_description = "a spark of enlightenment"
 
 /datum/reagent/buff/intelligence/on_mob_life(mob/living/carbon/M)
 	testing("int pot in system")
@@ -240,8 +240,8 @@
 
 /datum/reagent/buff/constitution
 	name = "Constitution"
-	color = "#130604"
-	taste_description = "bile"
+	color = "#d9bfcc"
+	taste_description = "the will to persevere"
 
 /datum/reagent/buff/constitution/on_mob_life(mob/living/carbon/M)
 	testing("con pot in system")
@@ -254,8 +254,8 @@
 
 /datum/reagent/buff/endurance
 	name = "Endurance"
-	color = "#ffff00"
-	taste_description = "gote urine"
+	color = "#5c8a8a"
+	taste_description = "a blessed second wind"
 
 /datum/reagent/buff/endurance/on_mob_life(mob/living/carbon/M)
 	testing("end pot in system")
@@ -268,8 +268,8 @@
 
 /datum/reagent/buff/speed
 	name = "Speed"
-	color = "#ffff00"
-	taste_description = "raw egg yolk"
+	color = "#99ddff"
+	taste_description = "carbonated, energized herbs"
 
 /datum/reagent/buff/speed/on_mob_life(mob/living/carbon/M)
 	testing("spd pot in system")
@@ -282,8 +282,8 @@
 
 /datum/reagent/buff/fortune
 	name = "Fortune"
-	color = "#ffff00"
-	taste_description = "pig urine"
+	color = "#ff9900"
+	taste_description = "lavish riches on the tongue"
 
 /datum/reagent/buff/fortune/on_mob_life(mob/living/carbon/M)
 	testing("luck pot in system")
@@ -500,4 +500,4 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 		M.reagents.add_reagent(src, rand(1,3))
 		to_chat(M, span_small("I feel even worse..."))
 	return ..()
-	
+


### PR DESCRIPTION
## About The Pull Request

Alchemists and apocatharies rejoice! No longer will you be brewing things that taste like various animal urines or look similar to another potion you just brewed and oh god did you mix the batches or forget the recipe or---

Very self-serving first-time PR that I wanted to do only for the stat buff potions but honestly, why not sort out some of the other colourations too.

_Change Breakdown;_

Health Potion/Mana Potion/Stamina Potions have had their normal version and strong version colours swapped, so the stronger versions are deeper, more saturated as one would expect.
Taste descriptions untouched.

Antidote and Strong Antidote are a lilacy colour with the weaker version a lighter shade.
Antidote tastes like "cleansing river water".
Strong Antidote tastes like "sweet salvation".

Buff stat potions have been recoloured to be more appropriate for their stat or the ingrediants crafted to make them, and are brighter than the above mainstay potions.
Strength tastes like "burning fire and invigoration".
Perception tastes like "a chalky, bitter awareness".
Intelligence tastes like "a spark of enlightenment".
Constitution tastes like "the will to persevere".
Endurance tastes like "a blessed second wind".
Speed tastes like "carbonated, energized herbs". ( energy drink potion?? :J )
Fortune tastes like "lavish riches on the tongue".

## Testing Evidence

![image](https://github.com/user-attachments/assets/e0f30b39-956a-4133-9ae0-c714115e3a23)

The Spread. (Strong Health Potion looks very dark here but it's a bit lighter in actuality)

## Why It's Good For The Game

 Potions should look good and taste not like piss! And also make sense in the fantasical concept of Solaris. Or at least look appealing and 'different enough'. I dunno. Potions cool funny yay.
