### PR TITLE
Is it really that hard to remember what someones species is?

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -150,6 +150,7 @@
 			else
 				referred_gender = "Androgynous"
 		known_people[H.real_name]["FGENDER"] = referred_gender
+		known_people[H.real_name]["FSPECIES"] = H.dna.species.name
 		known_people[H.real_name]["FAGE"] = H.age
 
 /datum/mind/proc/person_knows_me(person) //we are added to their lists
@@ -181,6 +182,7 @@
 					else
 						referred_gender = "Androgynous"
 				M.known_people[H.real_name]["FGENDER"] = referred_gender
+				M.known_people[H.real_name]["FSPECIES"] = H.dna.species.name
 				M.known_people[H.real_name]["FAGE"] = H.age
 				
 
@@ -227,12 +229,13 @@
 			continue
 		var/fjob = known_people[P]["FJOB"]
 		var/fgender = known_people[P]["FGENDER"]
+		var/fspecies = known_people[P]["FSPECIES"]
 		var/fage = known_people[P]["FAGE"]
 		var/fheresy = known_people[P]["FHERESY"]
 		if(fcolor && fjob)
 			if (fheresy)
 				contents +="<B><font color=#f1d669>[fheresy]</font></B> "
-			contents += "<B><font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font></B><BR>[fjob], [capitalize(fgender)], [fage]"
+			contents += "<B><font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font></B><BR>[fjob], [fspecies], [capitalize(fgender)], [fage]"
 			contents += "<BR>"
 
 	var/datum/browser/popup = new(user, "PEOPLEIKNOW", "", 260, 400)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -216,9 +216,13 @@
 		H.cmode_music = cmode_music
 
 	if(H.mind.special_role == "Court Agent" || H.mind.assigned_role == "Bandit" || H.mind.assigned_role == "Wretch") //For obfuscating Court Agents & Bandits in Actors list
-		GLOB.actors_list[H.mobid] = "[H.real_name] as Adventurer<BR>"
+		if (istype(H, /mob/living/carbon/human)) //For determining if the actor has a species name to display
+			var/mob/living/carbon/human/Hu = H 
+			GLOB.actors_list[H.mobid] = "[H.real_name] as the [Hu.dna.species.name] Adventurer<BR>"
+		else
+			GLOB.actors_list[H.mobid] = "[H.real_name] as Adventurer<BR>"
 	else
-		if (istype(H, /mob/living/carbon/human))
+		if (istype(H, /mob/living/carbon/human)) //For determining if the actor has a species name to display
 			var/mob/living/carbon/human/Hu = H
 			GLOB.actors_list[H.mobid] = "[H.real_name] as the [Hu.dna.species.name] [H.mind.assigned_role]<BR>"
 		else

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -218,7 +218,11 @@
 	if(H.mind.special_role == "Court Agent" || H.mind.assigned_role == "Bandit" || H.mind.assigned_role == "Wretch") //For obfuscating Court Agents & Bandits in Actors list
 		GLOB.actors_list[H.mobid] = "[H.real_name] as Adventurer<BR>"
 	else
-		GLOB.actors_list[H.mobid] = "[H.real_name] as [H.mind.assigned_role]<BR>"
+		if (istype(H, /mob/living/carbon/human))
+			var/mob/living/carbon/human/Hu = H
+			GLOB.actors_list[H.mobid] = "[H.real_name] as the [Hu.dna.species.name] [H.mind.assigned_role]<BR>"
+		else
+			GLOB.actors_list[H.mobid] = "[H.real_name] as [H.mind.assigned_role]<BR>"
 
 /client/verb/set_mugshot()
 	set category = "OOC"


### PR DESCRIPTION
## About The Pull Request

This PR adds known people's species to your memory list. No longer will you remember their name, job, gender, and age, but whether they're a human or a moff just slips from your memory. It also adds the species to the actors list.

## Testing Evidence

![actors](https://github.com/user-attachments/assets/c933afd4-97eb-415e-8c45-d2a96b1b4410)
![actor2s](https://github.com/user-attachments/assets/c5eb6d51-4b2b-4fa7-bf11-5793fc6b320b)

## Why It's Good For The Game

Not being able to remember what species someone is is, frankly, a bit weird, as it's a pretty big thing to not remember. By being able to remember them now, it's easier to know who someone is talking about when they say "The lupian warden" or the likes.
