### PR TITLE
Instantaneous Net Removal Fix

### DIFF
--- a/code/game/objects/items/rogueitems/ropechainbola.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola.dm
@@ -195,6 +195,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "net"
 	breakouttime = 35//easy to apply, easy to break out of
+    slipouttime = 45 //freeballing a number here - please adjust
 	gender = NEUTER
 	var/knockdown = 0
 

--- a/code/game/objects/items/rogueitems/ropechainbola.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola.dm
@@ -194,8 +194,8 @@
 	throwforce = 5
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "net"
-	breakouttime = 35//easy to apply, easy to break out of
-    slipouttime = 45 //freeballing a number here - please adjust
+	breakouttime = 35 //easy to apply, easy to break out of
+	slipouttime = 45 //freeballing a number here - please adjust
 	gender = NEUTER
 	var/knockdown = 0
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Nets fall into a strange position where if your character is below ten strength, they will 'slip out' of the net instantly. While those with greater than fifteen strength will still retain their ability to 'cuff break' their way out instantly - it is the awkward Goldilocks zone of people with strength between eleven to fifteen that suffer beneath the 'fast breakout' curse.

Bring your attention first to net themselves - https://github.com/NovaSector/Solaris/blob/5a365b9f2415d6a887222303591a712808ff4c07/code/game/objects/items/rogueitems/ropechainbola.dm#L197

Note that they have a break-out time of 35 - roughly 3.5 seconds. This timer as reflected across other restraints, such as rope, is the 'shorter' of two timers, the other being 'slip out' time. This 'slip out' is used by characters attempting to resist out of their bondage with less than ten strength. Note that nets do no specify this time.

Now we look at the game logic behind resisting against bindings - https://github.com/NovaSector/Solaris/blob/5a365b9f2415d6a887222303591a712808ff4c07/code/modules/mob/living/carbon/carbon.dm#L376

On line 381, break-out time is set to slip-out time - this is effective across all bindings, save for nets, which do not have a specified slip-out time, defaulting instead to 0.

This value is only ever modified by those with strength enough to possess the 'fast cuffbreak' trait (11-15 strength) - and is not touched by those with strength too high or too low, resulting in the behavior I feel is erroneous.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

![image](https://github.com/user-attachments/assets/1f6bad0b-3376-4b39-aa4d-73c3a2d315ba)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->

While resisting out of a net should not be an exhaustive process, due to the nature of how rapidly they can be applied, it should not be outright trivial. A 'breakout' time of 35 and a 'slipout' time of 45 is my proposal - this rewards characters with 'above average' strength with a faster means of escaping a net, while removing the erroneous behavior that those with low-strength can instantaneously escape the restraint.

This change does nothing to modify the instant breakout possessed of characters above 15 strength.
