### PR TITLE
[Bug Fix & Minor Beautification] The swedish chef now gets a backpack, and I've also stretched your class

### DIFF
--- a/code/controllers/subsystem/rogue/role_class_handler/class_select_handler/class_select_handler.dm
+++ b/code/controllers/subsystem/rogue/role_class_handler/class_select_handler/class_select_handler.dm
@@ -272,7 +272,7 @@
 	</html>
 	"}
 
-	linked_client << browse(data, "window=class_handler_main;size=330x430;can_close=0;can_minimize=0;can_maximize=0;can_resize=1;titlebar=1")
+	linked_client << browse(data, "window=class_handler_main;size=330x480;can_close=0;can_minimize=0;can_maximize=0;can_resize=1;titlebar=1")
 
 /datum/class_select_handler/proc/class_select_slop()
 

--- a/code/modules/jobs/job_types/roguetown/external/adventurer/types/pilgrim/rare/Lchef.dm
+++ b/code/modules/jobs/job_types/roguetown/external/adventurer/types/pilgrim/rare/Lchef.dm
@@ -29,7 +29,7 @@
 	cloak = /obj/item/clothing/cloak/apron
 	head = /obj/item/clothing/head/roguetown/chef
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
-	backr = /obj/item/storage/backpack/rogue/backpack
+	backl = /obj/item/storage/backpack/rogue/backpack
 	neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	beltr = /obj/item/cooking/pan


### PR DESCRIPTION
## About The Pull Request

A bug was reported in which the master chef did not spawn with a backpack and thus dropped all their ingredients on the ground like an unhygienic un-master chef. The typo causing this got fixed!

Given this was already fixing a minor bug with classes, I also stretched out the class selection menu so that more classes can fit in it without the ugly scrollbar showing up, or it showing up when you hover over a class.

## Testing Evidence

_An after/before picture of the class menu. Google "person wearing backpack" to get an idea of what the master chef now looks like._

![Untitled](https://github.com/user-attachments/assets/f8f5075a-78fc-400e-a1c2-f8e20a8b2b3f)

## Why It's Good For The Game

Minor bugfix is probably a good thing, and the class menu looks a bit nicer now.
