### PR TITLE
Post job reshuffle fixes

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -11130,7 +11130,8 @@
 /obj/structure/mineral_door/wood/donjon{
 	lockid = "deacon";
 	name = "Deacon's Clinic";
-	dir = 1
+	dir = 1;
+	locked = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/physician)
@@ -12143,7 +12144,8 @@
 "faE" = (
 /obj/structure/mineral_door/wood/donjon{
 	lockid = "deacon";
-	name = "Deacon's Clinic"
+	name = "Deacon's Clinic";
+	locked = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/physician)

--- a/code/modules/jobs/job_types/roguetown/mages_university/sidefolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/mages_university/sidefolk/mage_apprentice.dm
@@ -29,7 +29,6 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 	pants = /obj/item/clothing/under/roguetown/tights/random
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/book/granter/spellbook/magician
 	beltr = /obj/item/storage/keyring/mages_university
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff


### PR DESCRIPTION
- The keep is no longer AA.
- Magician's associates only get one book, not two. They have the opportunity to make it themselves, now, too.