### PR TITLE
Gunsmithing Ingredient QoL

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -195,5 +195,5 @@
 	name = "firepowder flask"
 	tools = list()
 	result = list(/obj/item/powderhorn = 1)
-	reqs = list(/obj/item/alch/coaldust = 1, /obj/item/alch/firedust = 1, /obj/item/natural/cured/essence = 1, /obj/item/natural/bone = 2, /obj/item/natural/fibers = 1)
+	reqs = list(/obj/item/alch/coaldust = 1, /obj/item/alch/firedust = 1, /obj/item/natural/bone = 2, /obj/item/natural/fibers = 1)
 	craftdiff = 4

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -1019,7 +1019,7 @@
 	name = "iron bullets (x5)"
 	reqs = list(/obj/item/ingot/iron = 1)
 	result = list(/obj/item/ammo_casing/caseless/rogue/bullet, /obj/item/ammo_casing/caseless/rogue/bullet, /obj/item/ammo_casing/caseless/rogue/bullet, /obj/item/ammo_casing/caseless/rogue/bullet, /obj/item/ammo_casing/caseless/rogue/bullet)
-	skillcraft = /datum/skill/craft/weaponsmithing
+	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 3
 
 
@@ -1027,5 +1027,5 @@
 	name = "steel bullets (x5)"
 	reqs = list(/obj/item/ingot/steel = 1)
 	result = list(/obj/item/ammo_casing/caseless/rogue/bullet/steel, /obj/item/ammo_casing/caseless/rogue/bullet/steel, /obj/item/ammo_casing/caseless/rogue/bullet/steel, /obj/item/ammo_casing/caseless/rogue/bullet/steel, /obj/item/ammo_casing/caseless/rogue/bullet/steel)
-	skillcraft = /datum/skill/craft/weaponsmithing
+	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4


### PR DESCRIPTION
## About The Pull Request

Alters the elements of gun crafting to be much more pleasant to engage with. Before, gunpowder required an item that had a CHANCE to spawn when a tamari devout scrapes a hide to create cured leather. This requirement has been removed, the rest remain. You still need firedust and a passing alchemist.

The other alteration is bullets have been moved from weapon smithing to engineering. No other alterations. Hopefully with these two small tweaks gun smithing will be a collaborative endeavor between the artificer and the alchemists in the university.

I will note, this does nothing to balance guns in combat, or to balance making the guns that exist. Only that it makes it more likely they'll be used by making ammunition less scarce.

## Testing Evidence

Bullets in the engineering menu
![bullets_to_engi](https://github.com/user-attachments/assets/f78276b7-7b63-4a51-b5c4-b2713069e759)

Gunpowder without natural/cured/essence
![firepowder_no_essence](https://github.com/user-attachments/assets/dcfc3625-ff35-4196-a2a7-34d9299c989b)


## Why It's Good For The Game

The steps to create a gun are prohibitively expensive already, and required too many specific professions to work together for it to be a natural rp occurrence. This hopefully gives players that use firearms a solid reason to patronize their artificer and the mages guild at large.
