### PR TITLE
More Gunsmith QoL tweaks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mages_university/artificer.dm
+++ b/code/modules/jobs/job_types/roguetown/mages_university/artificer.dm
@@ -26,7 +26,7 @@
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/labor/mining, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/firearms, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -1019,7 +1019,7 @@
 	name = "iron bullets (x5)"
 	reqs = list(/obj/item/ingot/iron = 1)
 	result = list(/obj/item/ammo_casing/caseless/rogue/bullet, /obj/item/ammo_casing/caseless/rogue/bullet, /obj/item/ammo_casing/caseless/rogue/bullet, /obj/item/ammo_casing/caseless/rogue/bullet, /obj/item/ammo_casing/caseless/rogue/bullet)
-	skillcraft = /datum/skill/craft/engineering
+	skillcraft = /datum/skill/craft/blacksmithing
 	craftdiff = 3
 
 
@@ -1027,5 +1027,5 @@
 	name = "steel bullets (x5)"
 	reqs = list(/obj/item/ingot/steel = 1)
 	result = list(/obj/item/ammo_casing/caseless/rogue/bullet/steel, /obj/item/ammo_casing/caseless/rogue/bullet/steel, /obj/item/ammo_casing/caseless/rogue/bullet/steel, /obj/item/ammo_casing/caseless/rogue/bullet/steel, /obj/item/ammo_casing/caseless/rogue/bullet/steel)
-	skillcraft = /datum/skill/craft/engineering
+	skillcraft = /datum/skill/craft/blacksmithing
 	craftdiff = 4


### PR DESCRIPTION

## About The Pull Request

One more round of small tweaks to integrate guns smoothly into smithing in general. 

1. Replaces maces 2 with firearms 2 for artificers. This is to avoid the pain of scream from powder burns when a gun is fired with no skill. In my mind, if the gunsmith trying to sell you the gun takes an injury from it, that makes it a harder sell. 

2. Moves ammo crafting yet again from engineering to blacksmithing. I realized last night the change I made means in the worst case, the lack of an artificer is a hard dead end for guns. On top of that, the virtue system already allows people to game the system to be able to do it themselves, so it was an arbitrary exclusion of the gun loop from blacksmiths for no tangible benefit. Now anyone can cast small metal balls from scrap iron because it really is not that hard. Fucking mel gibson does it in that one civil war movie out of toy soldiers so like, cmon yknow?

## Testing Evidence

Artificers no longer embarass themselves demonstrating a gun to a potential client
![firearms](https://github.com/user-attachments/assets/978cd915-307a-42c0-be52-949121f3b9d3)

Ammo to blacksmithing
![bullets](https://github.com/user-attachments/assets/d1086717-22b1-451e-b22a-e28c437e452c)


## Why It's Good For The Game

HANDGONNE GAMING. Basically now you can get ammo from any trained smith, but you need to consult an artificer for a gun, and the university for firepowder. Feels like a good start for balance in my gut.
