### PR TITLE
Re-Enable Werewolves

### DIFF
--- a/code/game/gamemodes/objectives_rogue.dm
+++ b/code/game/gamemodes/objectives_rogue.dm
@@ -19,8 +19,8 @@
 
 /datum/objective/werewolf
 	name = "conquer"
-	explanation_text = "You are a werewolf, a monsterous beast that walks the night in search of prey."
-	team_explanation_text = "Lycanthropy is a terrible disease that's been recorded in scattered accounts going back hundreds of years. Nightly transformations and prodigious increses in mass drive the body into an active state of insatiable starvation, driving animalistic, rabid behavior."
+	explanation_text = "You are a werewolf, a monsterous beast that walks the night in search of prey. Work with your fellow werewolves and protect the pack from all threats by any means necessary. Survival means blood."
+	team_explanation_text = "You are a werewolf, a monsterous beast that walks the night in search of prey. Work with your fellow werewolves and protect the pack from all threats by any means necessary. Survival means blood."
 	triumph_count = 5
 
 /datum/objective/werewolf/check_completion()

--- a/code/game/gamemodes/objectives_rogue.dm
+++ b/code/game/gamemodes/objectives_rogue.dm
@@ -19,7 +19,7 @@
 
 /datum/objective/werewolf
 	name = "conquer"
-	explanation_text = "Fear not the moon and Zira's light."
+	explanation_text = "You are a werewolf, a monsterous beast that walks the night in search of prey."
 	team_explanation_text = "Lycanthropy is a terrible disease that's been recorded in scattered accounts going back hundreds of years. Nightly transformations and prodigious increses in mass drive the body into an active state of insatiable starvation, driving animalistic, rabid behavior."
 	triumph_count = 5
 

--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -151,11 +151,6 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 				log_game("Major Antagonist: Rebellion")
 			*/
 			/*
-			if(26 to 50)
-				//"pick_vampires() was removed from here, normally they spawn together
-				pick_werewolves()
-				pick_bandits()
-				log_game("Antagonists: Werewolves & Bandits")
 			if(51 to 75)
 				pick_lich()
 				pick_bandits()
@@ -167,10 +162,17 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 				pick_vampires()
 				log_game("Antagonists: Vampyr")
 			*/
-			if(1 to 50)
+			if(1 to 25)
 				pick_bandits()
 				log_game("Antagonists: Bandits")
-			if(51 to 100)
+			if(26 to 50)
+				pick_werewolves()
+				pick_bandits()
+				log_game("Antagonists: Werewolves & Bandits")
+			if(51 to 74)
+				pick_werewolves()
+				log_game("Antagonists: Werewolves")
+			if(75 to 100)
 				log_game("Major Antagonist: Extended") //gotta put something here.
 
 		/* removing the "minor antagonist" system as we currently need them as major antagonist gamemodes while waiting for our own custom antags


### PR DESCRIPTION
## About The Pull Request
Re-enables werewolves with a rewritten objective, drastically cutting down the chance for the round to have no antagonists.
**Get silly.**

This'll be our least 'clean' antag re-addition, everything else will need heavy reworking or need to be built from the ground up. But hey, that's part of the fun.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Weights working as intended, not sure if boxfolk would like a different weighting than just quarters but it's alright so far.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
We need antagonists for a functioning game. Even OpenSS13 had multiple gamemodes - Traitor, Nukeops, Meteor, Monkey Mode...

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
