### PR TITLE
Gunsmith QoL 3

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -989,21 +989,21 @@
 
 /datum/crafting_recipe/roguetown/arquebus
 	name = "Arquebus"
-	reqs = list(/obj/item/ingot/steel = 16, /obj/item/ingot/bronze = 2, /obj/item/weaponcrafting/barrel = 1, /obj/item/weaponcrafting/receiver = 1, /obj/item/grown/log/tree/small = 1, /obj/item/weaponcrafting/stock = 1)
+	reqs = list(/obj/item/ingot/steel = 8, /obj/item/ingot/bronze = 2, /obj/item/weaponcrafting/barrel = 1, /obj/item/weaponcrafting/receiver = 1, /obj/item/grown/log/tree/small = 1, /obj/item/weaponcrafting/stock = 1)
 	result = list(/obj/item/gun/ballistic/arquebus)
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 5 //le ultimate challenge
 
 /datum/crafting_recipe/roguetown/handgonne
 	name = "Handgonne"
-	reqs = list(/obj/item/ingot/iron = 8, /obj/item/weaponcrafting/barrel = 1, /obj/item/weaponcrafting/receiver = 1, /obj/item/grown/log/tree/small = 1, /obj/item/weaponcrafting/stock = 1)
+	reqs = list(/obj/item/ingot/iron = 4, /obj/item/weaponcrafting/barrel = 1, /obj/item/weaponcrafting/receiver = 1, /obj/item/grown/log/tree/small = 1, /obj/item/weaponcrafting/stock = 1)
 	result = list(/obj/item/gun/ballistic/handgonne)
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/arquebuspistol
 	name = "Arquebus pistol"
-	reqs = list(/obj/item/ingot/steel = 8, /obj/item/ingot/bronze = 1 , /obj/item/weaponcrafting/barrel = 1, /obj/item/weaponcrafting/receiver = 1, /obj/item/grown/log/tree/small = 1)
+	reqs = list(/obj/item/ingot/steel = 4, /obj/item/ingot/bronze = 1 , /obj/item/weaponcrafting/barrel = 1, /obj/item/weaponcrafting/receiver = 1, /obj/item/grown/log/tree/small = 1)
 	result = list(/obj/item/gun/ballistic/arquebus_pistol)
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4


### PR DESCRIPTION
## About The Pull Request

Alright so, 3 days of playing artificer and focusing on guns. I think this is the last balance tweak I can justify and it's mostly to be more polite with co-existing with a busy blacksmith.

The Arquebus requires 16 ingots,  2 bronze ingots, a firearm barrel, firearm parts, a wooden stock, and a wooden log.

Each firearm parts consists of 2 steel ingots. Each firearm barrel is 2 iron ingots. This means an Arquebus costs **18 steel ingots for one gun, before ammo costs**. I am convinced by the comment next to the arquebus's craft difficulty that this is a decision that is not informed by balance as much as it is by "jokes". I've halved the steel ingot requirements specifically because this is a shared vital resource for the round. 

Honestly? From my time? I would personally lower it to 2/handgonne, 3/arquebus pistol, 5 arquebus. But this keeps them eye raiseingly expensive, which makes them something the nobles would collect and brag about I think.

## Testing Evidence

I don't actually know how to cleanly demonstrate this in a screenshot because gunsmithing creates a nightmare ingot pile. The recipe still works trust me.

## Why It's Good For The Game

As an artificer with standard mining, you kind of have to strip mine a spot for one item, and if you want to stock your peddler with a few firearms, that's going to make it get worse and worse for everyone else. This should let a given artificer make about 2-4 guns per round without anyone else noticing in the worst case for a blacksmith hellcrunch round.
