### PR TITLE
Fix the peace effect's sprite to the relief one.

### DIFF
--- a/code/modules/mob/living/overhead_effects.dm
+++ b/code/modules/mob/living/overhead_effects.dm
@@ -76,7 +76,7 @@
 	play_overhead_indicator('icons/mob/overhead_effects.dmi', "stress", 15, OBJ_LAYER, private = TRAIT_EMPATH, soundin = 'sound/ddstress.ogg')
 
 /mob/living/proc/play_relief_indicator()
-	play_overhead_indicator('icons/mob/overhead_effects.dmi', "stress", 15, OBJ_LAYER, private = TRAIT_EMPATH, soundin = 'sound/ddstress.ogg')
+	play_overhead_indicator('icons/mob/overhead_effects.dmi', "relief", 15, OBJ_LAYER, private = TRAIT_EMPATH, soundin = 'sound/ddrelief.ogg')
 
 /mob/living/proc/play_mental_break_indicator()
 	play_overhead_indicator('icons/mob/overhead_effects.dmi', "mentalbreak", 20, OBJ_LAYER)


### PR DESCRIPTION
## About The Pull Request
I have noticed that I always have been having the stress effect even at max peace. Turns out that the stress effect was set on both stress and relief events.

## Testing Evidence

https://github.com/user-attachments/assets/b595d728-aae7-4f6e-a249-e5071eaf4f7f

## Why It's Good For The Game

People with peace in mind shouldn't look like they are stressed.

