### PR TITLE
Merchant's export expansion 1 : You can export all wolf's parts, along with troll horns. Nerfs the sell price of half masks.

### DIFF
--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -28,6 +28,7 @@
 	desc = "the head of a fearsome wolf."
 	icon_state = "volfhead"
 	layer = 3.1
+	sellprice = 15
 
 //RTD make this a storage item and make clickign on animals with things put it in storage
 /obj/item/natural/saddle
@@ -78,6 +79,7 @@
 	desc = "The meatless remains of the dead. Whether it came from an animal or a person it all looks the same now."
 	blade_dulling = 0
 	max_integrity = 20
+	sellprice = 5
 	static_debris = null
 	obj_flags = null
 	firefuel = null

--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -66,6 +66,7 @@
 /obj/item/alch/viscera
 	name = "viscera"
 	icon_state = "viscera"
+	sellprice = 3
 	major_pot = /datum/alch_cauldron_recipe/big_health_potion
 	med_pot = /datum/alch_cauldron_recipe/health_potion
 	minor_pot = /datum/alch_cauldron_recipe/antidote
@@ -130,6 +131,7 @@
 	name = "sinew"
 	icon_state = "sinew"
 	dropshrink = 0.9
+	sellprice = 7
 	major_pot = /datum/alch_cauldron_recipe/stam_poison
 	med_pot = /datum/alch_cauldron_recipe/end_potion
 	minor_pot = /datum/alch_cauldron_recipe/health_potion
@@ -178,6 +180,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	grid_width = 32
 	grid_height = 64
+	sellprice = 5
 
 	major_pot = /datum/alch_cauldron_recipe/disease_cure
 	med_pot = /datum/alch_cauldron_recipe/health_potion
@@ -192,6 +195,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 64
 	grid_height = 64
+	sellprice = 30
 
 	major_pot = /datum/alch_cauldron_recipe/str_potion
 	med_pot = /datum/alch_cauldron_recipe/con_potion

--- a/code/modules/roguetown/roguecrafting/weaving.dm
+++ b/code/modules/roguetown/roguecrafting/weaving.dm
@@ -30,7 +30,7 @@
 	reqs = list(/obj/item/natural/cloth = 1,
 				/obj/item/natural/silk = 1)
 	craftdiff = 1
-	sellprice = 30
+	sellprice = 12
 
 /datum/crafting_recipe/roguetown/weaving/aeternus
 	name = "aeternus robes (3 cloth, 1 silk)"


### PR DESCRIPTION
## About The Pull Request
This adds a selling price to the wolf parts, troll horn and nerfs the selling price of silk half masks.
Wolf heads : 15 marks.
Bones : 5 marks each unit.
Tail bone : 5 marks.
Viscera : 3 marks.
Sinew : 7 marks.
Troll's horn : 30 marks.
Half mask : From 29 to 12 marks.


## Testing Evidence

Remember that prices can fluctuate each rounds, so it is not 100% exact.
![newprices](https://github.com/user-attachments/assets/4235b6b3-3bbb-4bee-959c-8f8cc384c02e)


## Why It's Good For The Game
Outside I see often wolf remains with bunch of visceras, bones, sinew, and the head left. You can already sell goblin heads, but to my surprise wolf heads do not have a selling price despite being an ambushing foe too.
This can encourage perhaps people to fully sell their hunts, in case there is no alchemist in town.

When I played merchant, people have brought troll horns to sell. They had no export value and without an alchemist in town, this was pretty much mechanically useless. I think giving some value in the horn can make a worthy reward to hunt such creature. (Also funny adventurers selling mob parts to NPC merchants trope)

Half-maks had an absurd selling price, 30. That was more than most of silk gear you can make ! And with only 1 cloth and 1 silk, the ratio for low effort/high value was very good. 
