### PR TITLE
Fix zombification stripping people of their organic biotypes by adding some parenthesis 

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -50,16 +50,16 @@
 #define BLOODCRAWL_EAT 2
 
 //Mob bio-types flags
-#define MOB_ORGANIC 	1 << 0
-#define MOB_MINERAL		1 << 1
-#define MOB_ROBOTIC 	1 << 2
-#define MOB_UNDEAD		1 << 3
-#define MOB_HUMANOID 	1 << 4
-#define MOB_BUG 		1 << 5
-#define MOB_BEAST		1 << 6
-#define MOB_EPIC		1 << 7 //megafauna
-#define MOB_REPTILE		1 << 8
-#define MOB_SPIRIT		1 << 9
+#define MOB_ORGANIC 	(1 << 0)
+#define MOB_MINERAL		(1 << 1)
+#define MOB_ROBOTIC 	(1 << 2)
+#define MOB_UNDEAD		(1 << 3)
+#define MOB_HUMANOID 	(1 << 4)
+#define MOB_BUG 		(1 << 5)
+#define MOB_BEAST		(1 << 6)
+#define MOB_EPIC		(1 << 7) //megafauna
+#define MOB_REPTILE		(1 << 8)
+#define MOB_SPIRIT		(1 << 9)
 
 //Organ defines for carbon mobs
 #define ORGAN_ORGANIC   1


### PR DESCRIPTION
## About The Pull Request

https://github.com/NovaSector/Solaris/blob/716af9c5382c1c1e7de48de02c5031a4e87968a4/code/modules/antagonists/roguetown/villain/zombie/zombie.dm#L189-L190
This code *looks* fine (if you know the black magic that is bitflags)
but it actually translates to `mob_biotypes &= ~1 << 3` which is horribly wrong
This means that anyone being cured of their zombie-ness, before *or* after turning, removes the organic biotype (and the mineral and robotic biotypes, I guess) in addition to the undead biotype.
The power of parenthesis.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/45ab94fc-822a-428e-bf34-12c9581bcc99)
![image](https://github.com/user-attachments/assets/6c94799e-1f5e-46b0-998f-d76a4a4527ec)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fix bug
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
