### PR TITLE
Necromancer Fix & New Ally-Mark Spell: Mark of the Gravebound

### DIFF
--- a/code/datums/ai/targetting_datum/simple_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simple_targetting_datum.dm
@@ -35,7 +35,7 @@
 
 	if(isliving(the_target)) //Targetting vs living mobs
 		var/mob/living/L = the_target
-		if(L.summoner && L.summoner == the_target.name) // won't attack whomever summoned it
+		if(living_mob.summoner && living_mob.summoner == the_target.name) // won't attack whomever summoned it
 			return FALSE
 		if(faction_check(living_mob, L) || L.stat)
 			return FALSE

--- a/code/modules/jobs/job_types/roguetown/external/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/external/adventurer/wretch.dm
@@ -257,6 +257,7 @@
 
 
 /datum/outfit/job/roguetown/wretch/necromancer/pre_equip(mob/living/carbon/human/H)
+	H.mind.current.faction += "[H.name]_faction"
 	head = /obj/item/clothing/head/roguetown/roguehood/black
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
@@ -290,6 +291,7 @@
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/bonechill)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/necromancer)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/gravemark)
 	H.mind.adjust_spellpoints(1)
 	GLOB.excommunicated_players += H.real_name
 	var/my_crime = input(H, "What is your crime?", "Crime") as text|null

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -113,12 +113,12 @@
 			return pick('sound/vo/mobs/skel/skeleton_idle (1).ogg','sound/vo/mobs/skel/skeleton_idle (2).ogg','sound/vo/mobs/skel/skeleton_idle (3).ogg')
 
 
-/mob/living/simple_animal/hostile/rogue/skeleton/Initialize(mapload, mob/user, cabal_affine = FALSE)
+/mob/living/simple_animal/hostile/rogue/skeleton/Initialize(mapload, mob/user, is_summoned = FALSE)
 	. = ..()
 	if(user)
 		summoner = user.name
-		if (cabal_affine)
-			faction |= "cabal"
+		if (is_summoned)
+			faction |= "[summoner]_faction"
 
 /mob/living/simple_animal/hostile/rogue/skeleton/Life()
 	. = ..()

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -212,23 +212,23 @@
 	exp_light = 2
 	exp_flash = 2
 	exp_fire = 0
-
+	
 /obj/effect/proc_holder/spell/targeted/gravemark
 	name = "Mark of the Gravebound"
-	desc =  "Adds or removes a target from the list of allies exempt from your undead's aggression."
+	desc = "Adds or removes a target from the list of allies exempt from your undead's aggression."
 
 /obj/effect/proc_holder/spell/targeted/gravemark/cast(list/targets, mob/user)
 	. = ..()
 	for (var/mob/living/mob in targets)
 		if (!mob?.mind)
-			to_chat(user, span_warning("This one lacks the spark of sentience"))
+			to_chat(user, span_warning("This one lacks the spark of sentience."))
 			continue
-		if (mob == usr)
-			to_chat(user, span_warning("It would be unwise to make an enemy of my skeletons."))
+		if (mob == user) // You used `usr` — prefer `user` for clarity in spells.
+			to_chat(user, span_warning("It would be unwise to make an enemy of your own skeletons."))
 			continue
-		if ("[usr.name]_faction" in mob.mind.current.faction)
-			mob.mind.current.faction -= "[usr.name]_faction"
-			usr.say("Your safety is forfeit, your fate bone-bound.")
+		if ("[user.name]_faction" in mob.mind.current.faction)
+			mob.mind.current.faction -= "[user.name]_faction"
+			user.say("Your safety is forfeit, your fate bone-bound.")
 		else
-			mob.mind.current.faction += "[usr.name]_faction"
-			usr.say("Marked by bone and spared by death.")
+			mob.mind.current.faction += "[user.name]_faction"
+			user.say("Marked by bone and spared by death.")

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -115,7 +115,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	charge_max = 30 SECONDS
-	var/cabal_affine = FALSE
+	var/is_summoned = FALSE
 
 /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/cast(list/targets, mob/living/user)
 	. = ..()
@@ -124,22 +124,22 @@
 	if(isopenturf(T))
 		switch(skeleton_roll)
 			if(1 to 20)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T, user, is_summoned)
 			if(21 to 40)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T, user, is_summoned)
 			if(41 to 60)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T, user, is_summoned)
 			if(61 to 80)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T, user, is_summoned)
 			if(81 to 100)
-				new /mob/living/simple_animal/hostile/rogue/skeleton(T, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton(T, user, is_summoned)
 		return TRUE
 	else
 		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))
 		return FALSE
 
 /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/necromancer
-	cabal_affine = TRUE
+	is_summoned = TRUE
 	charge_max = 45 SECONDS
 
 /obj/effect/proc_holder/spell/invoked/projectile/sickness
@@ -212,3 +212,23 @@
 	exp_light = 2
 	exp_flash = 2
 	exp_fire = 0
+
+/obj/effect/proc_holder/spell/targeted/gravemark
+	name = "Mark of the Gravebound"
+	desc =  "Adds or removes a target from the list of allies exempt from your undead's aggression."
+
+/obj/effect/proc_holder/spell/targeted/gravemark/cast(list/targets, mob/user)
+	. = ..()
+	for (var/mob/living/mob in targets)
+		if (!mob?.mind)
+			to_chat(user, span_warning("This one lacks the spark of sentience"))
+			continue
+		if (mob == usr)
+			to_chat(user, span_warning("It would be unwise to make an enemy of my skeletons."))
+			continue
+		if ("[usr.name]_faction" in mob.mind.current.faction)
+			mob.mind.current.faction -= "[usr.name]_faction"
+			usr.say("Your safety is forfeit, your fate bone-bound.")
+		else
+			mob.mind.current.faction += "[usr.name]_faction"
+			usr.say("Marked by bone and spared by death.")


### PR DESCRIPTION
## About The Pull Request

This PR refines necromancer summon behaviour and introduces player-controlled faction management:

🧟‍♂️ Fixes skeleton behaviour so that necromancer summons no longer spawn hostile to their summoners.

🕯️ Adds a new spell: Mark of the Grave bound: allows necromancers to manually mark or unmark targets as allies. Marked individuals will be ignored by the necromancer's summoned skeletons.

🧾 Implements per-caster factions to isolate summon targeting logic per necromancer.

🧹 Cleans up old cabal variable, we don't have a Zizo cult here.

## Testing Evidence

https://github.com/user-attachments/assets/6d606aec-7d86-4c90-bb88-3b6c6aef457e

## Why It's Good For The Game

This enhances necromancer play by:

- Eliminating unintended summon aggression.
- Giving necromancers meaningful control over who their minions attack.
