### PR TITLE
[FIX] Hood toggling breaking summoning orders

### DIFF
--- a/code/datums/ai/targetting_datum/simple_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simple_targetting_datum.dm
@@ -34,7 +34,6 @@
 		return FALSE
 
 	if(isliving(the_target)) //Targetting vs living mobs
-		var/mob/living/L = the_target
 		if(istype(the_target, /mob/living/carbon/human))
 			var/mob/living/carbon/human/carbon_target = the_target
 			if(living_mob.summoner && carbon_target.mind && living_mob.summoner == carbon_target.mind.name) // won't attack whomever summoned it

--- a/code/datums/ai/targetting_datum/simple_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simple_targetting_datum.dm
@@ -34,10 +34,13 @@
 		return FALSE
 
 	if(isliving(the_target)) //Targetting vs living mobs
+		var/mob/living/L = the_target
 		if(istype(the_target, /mob/living/carbon/human))
 			var/mob/living/carbon/human/carbon_target = the_target
 			if(living_mob.summoner && carbon_target.mind && living_mob.summoner == carbon_target.mind.name) // won't attack whomever summoned it
 				return FALSE
+		if(faction_check(living_mob, L) || L.stat)
+			return FALSE
 		return TRUE
 
 	return FALSE

--- a/code/datums/ai/targetting_datum/simple_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simple_targetting_datum.dm
@@ -35,10 +35,10 @@
 
 	if(isliving(the_target)) //Targetting vs living mobs
 		var/mob/living/L = the_target
-		if(living_mob.summoner && living_mob.summoner == the_target.name) // won't attack whomever summoned it
-			return FALSE
-		if(faction_check(living_mob, L) || L.stat)
-			return FALSE
+		if(istype(the_target, /mob/living/carbon/human))
+			var/mob/living/carbon/human/carbon_target = the_target
+			if(living_mob.summoner && carbon_target.mind && living_mob.summoner == carbon_target.mind.name) // won't attack whomever summoned it
+				return FALSE
 		return TRUE
 
 	return FALSE

--- a/code/modules/jobs/job_types/roguetown/external/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/external/adventurer/wretch.dm
@@ -257,7 +257,7 @@
 
 
 /datum/outfit/job/roguetown/wretch/necromancer/pre_equip(mob/living/carbon/human/H)
-	H.mind.current.faction += "[H.name]_faction"
+	H.mind.current.faction += "[H.mind.name]_[H.ckey]_faction"
 	head = /obj/item/clothing/head/roguetown/roguehood/black
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -116,9 +116,9 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/Initialize(mapload, mob/user, is_summoned = FALSE)
 	. = ..()
 	if(user)
-		summoner = user.name
+		summoner = user.mind.name
 		if (is_summoned)
-			faction |= "[summoner]_faction"
+			faction = "[user.mind.name]_[user.ckey]_faction"
 
 /mob/living/simple_animal/hostile/rogue/skeleton/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/rogue/creacher/mossback.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mossback.dm
@@ -51,7 +51,7 @@
 	AddElement(/datum/element/ai_retaliate)
 	ai_controller.set_blackboard_key(BB_BASIC_FOODS, food_type)
 	if(user)
-		summoner = user.name
+		summoner = user.mind.name
 		if (townercrab)
 			faction = list("neutral")
 			tamed(1)

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -226,9 +226,9 @@
 		if (mob == user) // You used `usr` — prefer `user` for clarity in spells.
 			to_chat(user, span_warning("It would be unwise to make an enemy of your own skeletons."))
 			continue
-		if ("[user.name]_faction" in mob.mind.current.faction)
-			mob.mind.current.faction -= "[user.name]_faction"
+		if ("[user.mind.name]_[user.ckey]_faction" in mob.mind.current.faction)
+			mob.mind.current.faction -= "[user.mind.name]_[user.ckey]_faction"
 			user.say("Your safety is forfeit, your fate bone-bound.")
 		else
-			mob.mind.current.faction += "[user.name]_faction"
+			mob.mind.current.faction += "[user.mind.name]_[user.ckey]_faction"
 			user.say("Marked by bone and spared by death.")

--- a/modular_azurepeak/code/modules/spells/minion_order.dm
+++ b/modular_azurepeak/code/modules/spells/minion_order.dm
@@ -30,7 +30,7 @@
 	// Target is another mob
 	else if(ismob(target))
 		var/mob/living/mob_target = target
-		if(caster.faction_check_mob(target) || (mob_target.summoner && mob_target.summoner == caster.name))
+		if(caster.faction_check_mob(target) || (mob_target.summoner && mob_target.summoner == caster.mind.name))
 			src.process_minions(order_type = "aggressive", target = target)
 			return
 		else
@@ -50,7 +50,7 @@
 		if (istype(other_mob, /mob/living/simple_animal) && !other_mob.client) // Only simple_mobs for now
 			var/mob/living/simple_animal/minion = other_mob
 
-			if ((faction_ordering && caster.faction_check_mob(minion)) || (!faction_ordering && minion.summoner == caster.name))
+			if ((faction_ordering && caster.faction_check_mob(minion)) || (!faction_ordering && minion.summoner == caster.mind.name))
 
 				minion.ai_controller.clear_blackboard_key(BB_FOLLOW_TARGET)
 				minion.ai_controller.clear_blackboard_key(BB_BASIC_MOB_CURRENT_TARGET)


### PR DESCRIPTION
## About The Pull Request

[Fix] We were storing the summoner name for summons as caster.name. We also change caster.name when their face is hidden into "unknown". This was also used in my necromancer factions code since "well we're doing it that way so it works, right ?"

Wrong, it doesn't. Anyway, we're now using caster.mind.name for Summon spells summoned summons' summoners. So you switching between hidden face or shown face shouldn't make your minions stop obeying you. Also, the wretch necromancer's factions are now determined by [necromancer.mind.name]_[necromancer.ckey] which make it so, same, faction don't break when someone hides their face and you can't sneak into a faction somehow by having the same character name.