### PR TITLE
Fixing Faction Failures in Fratricidal Skeletons

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -112,13 +112,16 @@
 		if("idle")
 			return pick('sound/vo/mobs/skel/skeleton_idle (1).ogg','sound/vo/mobs/skel/skeleton_idle (2).ogg','sound/vo/mobs/skel/skeleton_idle (3).ogg')
 
-
+//Sorta duct tape thing. Solaris doesn't have the Necromancers as part of the Undead faction. So they are attacked by PVE undead. Removing the necromancer's skeletons from the undead faction so they can defend their master.
 /mob/living/simple_animal/hostile/rogue/skeleton/Initialize(mapload, mob/user, is_summoned = FALSE)
 	. = ..()
 	if(user)
 		summoner = user.mind.name
 		if (is_summoned)
-			faction = "[user.mind.name]_[user.ckey]_faction"
+			faction |= "[user.mind.name]_[user.ckey]_faction"
+			if (!("undead" in user.faction)) //We don't want the lich antag to get murdered by its own minion
+				name = "Deathbound"
+				faction -= "undead"
 
 /mob/living/simple_animal/hostile/rogue/skeleton/Life()
 	. = ..()


### PR DESCRIPTION
Quick fix, Necromancer skeletons shouldn't murder each other. This was the result of trying to decouple them from the undead faction by forcing them to the caster's faction only. (For some reason.)

Also checked, lich minions function correction too, just in case.