### PR TITLE
Disables the initialization of Atmos Adjacency

### DIFF
--- a/code/controllers/subsystem/adjacent_air.dm
+++ b/code/controllers/subsystem/adjacent_air.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(adjacent_air)
 	name = "Atmos Adjacency"
-	flags = SS_BACKGROUND
+	flags = SS_NO_FIRE
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 	wait = 10
 	priority = FIRE_PRIORITY_ATMOS_ADJACENCY
@@ -14,6 +14,9 @@ SUBSYSTEM_DEF(adjacent_air)
 	#endif
 
 /datum/controller/subsystem/adjacent_air/Initialize()
+	if(flags & SS_NO_FIRE)
+		return ..()
+
 	while(length(queue))
 		fire(mc_check = FALSE)
 	return ..()


### PR DESCRIPTION
## About The Pull Request
Atmos literally doesn't even work on Solaris, having Atmos Adjacency initializing just adds an unnecessary delay to the start of the round, so I removed it.

## Testing Evidence
I forgot to take a screenshot, but trust me, it displayed 0 second in Dream Daemon.

## Why It's Good For The Game
Faster init == better time developing stuff for the game. Also makes the server be initialized faster, which is good.
