### PR TITLE
The Forsaken Bastille - A new dungeon for Solaris Ridge

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -1252,6 +1252,12 @@
 /obj/item/clothing/cloak/darkcloak/bear,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/abandoned_manor)
+"aAn" = (
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 8
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "aAE" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors)
@@ -1637,6 +1643,15 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
+"aJD" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 6
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "aJI" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -2558,6 +2573,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
+"bcM" = (
+/mob/living/simple_animal/hostile/rogue/skeleton,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "bcS" = (
 /obj/structure/winch{
 	dir = 4;
@@ -2775,6 +2796,10 @@
 /obj/machinery/light/rogue/torchholder/directional/west,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
+"bib" = (
+/obj/structure/flora/roguetree/underworld,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "bik" = (
 /obj/structure/stairs{
 	dir = 1
@@ -4602,6 +4627,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"bUj" = (
+/obj/structure/toilet,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "bUq" = (
 /obj/structure/bars,
 /obj/structure/bars/passage{
@@ -5715,6 +5746,9 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark)
+"cvH" = (
+/turf/open/floor/rogue/greenstone,
+/area/rogue/outdoors/beach/forest)
 "cvZ" = (
 /obj/structure/closet/crate/chest{
 	base_icon_state = "woodchestalt";
@@ -6897,6 +6931,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/old_ruin)
+"cVK" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/cave)
 "cVQ" = (
 /obj/structure/stairs{
 	dir = 1
@@ -7344,6 +7385,16 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"dgd" = (
+/obj/structure/table/wood,
+/obj/structure/fluff/walldeco/med5{
+	pixel_x = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "dge" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -7952,6 +8003,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"duu" = (
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	dir = 8
+	},
+/turf/open/floor/rogue/greenstone{
+	dir = 1
+	},
+/area/rogue/outdoors/beach/forest)
 "duy" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/tile,
@@ -9454,6 +9514,9 @@
 /obj/item/rogueweapon/thresher,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"ebC" = (
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/outdoors/beach/forest)
 "ebG" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -11015,6 +11078,10 @@
 /obj/effect/landmark/start/prisonerr,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
+"eGi" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/beach/forest)
 "eGj" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11286,6 +11353,10 @@
 "eMx" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woods)
+"eNd" = (
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "eNp" = (
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
@@ -11464,6 +11535,10 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/dungeon/licharena)
+"eQQ" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/wolf,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/outdoors/beach/forest)
 "eQT" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -13009,6 +13084,9 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"fwS" = (
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/outdoors/beach/forest)
 "fwX" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -14539,6 +14617,12 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
+"gfT" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/cave)
 "gfU" = (
 /obj/structure/stairs{
 	dir = 8
@@ -14564,6 +14648,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"ggA" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/cave)
 "ggS" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
@@ -17140,6 +17231,12 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"hkO" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 9
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "hkR" = (
 /obj/structure/well/fountain{
 	pixel_x = -16
@@ -19545,6 +19642,10 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"ijH" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "ijJ" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
 	dir = 1
@@ -20625,6 +20726,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter/woods)
+"iFL" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/beach/forest)
 "iGc" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/under/roguetown/trou/leather,
@@ -20735,6 +20840,12 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"iJM" = (
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "iJP" = (
 /obj/machinery/light/rogue/firebowl{
 	light_color = "#b30202"
@@ -21275,6 +21386,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"iTB" = (
+/obj/structure/fluff/walldeco/med3{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "iTJ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -21372,6 +21491,12 @@
 "iVz" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/dungeon/vulnafir)
+"iVB" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/beach/forest)
 "iVE" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/garrison)
@@ -22882,6 +23007,12 @@
 /obj/structure/spacevine,
 /turf/open/water/swamp/deep,
 /area/rogue/under/town/basement)
+"jCq" = (
+/obj/structure/stairs/stone{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/cave)
 "jCt" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassred,
@@ -23721,6 +23852,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap)
+"jVb" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "jVf" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/rack/rogue/shelf/biggest,
@@ -26347,6 +26484,11 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
+"lbV" = (
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/indoors/cave)
 "lbY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -27979,6 +28121,12 @@
 	dir = 4
 	},
 /area/rogue/indoors/town)
+"lKP" = (
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "lKS" = (
 /turf/open/floor/rogue/church,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -28105,6 +28253,10 @@
 "lNr" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"lNG" = (
+/obj/structure/stone_tile/slab/cracked,
+/turf/closed,
+/area/rogue/outdoors/beach/forest)
 "lNY" = (
 /obj/structure/bars/passage/shutter{
 	desc = "Extremely strong. I don't think I can easily get through this with brute force. Where might the way to open it be?";
@@ -28310,6 +28462,11 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"lSw" = (
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "lSK" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -28819,6 +28976,14 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
+"mec" = (
+/obj/structure/stairs/stone{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "mef" = (
 /obj/item/clothing/shoes/roguetown/boots,
 /turf/open/water/swamp,
@@ -29829,6 +29994,12 @@
 "mCe" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
+"mCg" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "mCk" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/rooftop{
@@ -31238,6 +31409,12 @@
 /obj/item/grown/log/tree/stake,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"ngu" = (
+/obj/structure/mineral_door/wood,
+/turf/open/floor/rogue/greenstone{
+	dir = 4
+	},
+/area/rogue/outdoors/beach/forest)
 "ngC" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -31913,6 +32090,12 @@
 "nsT" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains)
+"nsX" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/beach/forest)
 "nsZ" = (
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -32208,6 +32391,12 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"nzP" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "nzW" = (
 /obj/structure/chair/bench/church/smallbench{
 	dir = 1
@@ -35235,6 +35424,9 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"oPv" = (
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/cave)
 "oPA" = (
 /obj/structure/fluff/statue/aeternus/gold,
 /obj/structure/fluff/walldeco/church/line,
@@ -35443,6 +35635,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"oVo" = (
+/obj/structure/gate{
+	name = "Tsoridys' Mercy"
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/outdoors/beach/forest)
 "oVs" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/east,
 /obj/effect/decal/wood/herringbone{
@@ -36472,6 +36670,11 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
+"pqX" = (
+/turf/open/floor/rogue/blocks/green{
+	dir = 4
+	},
+/area/rogue/outdoors/beach/forest)
 "prq" = (
 /obj/machinery/light/small{
 	mouse_opacity = 0;
@@ -36623,6 +36826,12 @@
 /obj/item/rogueweapon/sword/silver,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/goblinfort)
+"pug" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "pun" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/psycross,
@@ -37255,6 +37464,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
+"pGG" = (
+/obj/structure/mineral_door/wood,
+/turf/open/floor/rogue/greenstone{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "pGH" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grasscold,
@@ -37862,6 +38077,11 @@
 /obj/machinery/loom,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pTA" = (
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 1
+	},
+/area/rogue/outdoors/beach/forest)
 "pTF" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -38766,6 +38986,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dungeon/vulnafir)
+"qqz" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "qqD" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -39541,6 +39767,10 @@
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/dungeon/abandoned_manor)
+"qGD" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "qGE" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 8
@@ -39953,6 +40183,11 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/manor)
+"qOV" = (
+/turf/open/floor/rogue/blocks/green{
+	dir = 1
+	},
+/area/rogue/outdoors/beach/forest)
 "qPl" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -40074,6 +40309,11 @@
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach)
+"qRS" = (
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 4
+	},
+/area/rogue/outdoors/beach/forest)
 "qRV" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -40147,6 +40387,12 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpotnew,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"qUh" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "qUj" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -40840,6 +41086,10 @@
 /obj/structure/bars,
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"rjm" = (
+/obj/structure/stone_tile/slab/cracked,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "rjo" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "scary_manor3"
@@ -41393,6 +41643,12 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"rva" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "rvj" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/axian_my_sweet,
@@ -41701,6 +41957,11 @@
 /obj/item/reagent_containers/glass/cup/silver,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"rCo" = (
+/turf/closed/wall/mineral/rogue/roofwall/innercorner{
+	dir = 4
+	},
+/area/rogue/outdoors/beach/forest)
 "rCr" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
@@ -44510,6 +44771,13 @@
 /obj/effect/mapping_helpers/access/yeomen/merchant/shop,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
+"sMF" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/cave)
 "sMJ" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/dirt/road,
@@ -44878,6 +45146,9 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
+"sVG" = (
+/turf/closed/wall/mineral/rogue/stone/window,
+/area/rogue/outdoors/beach/forest)
 "sVK" = (
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -46932,6 +47203,14 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"tSD" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "tSE" = (
 /obj/machinery/light/rogue/torchholder/directional/west,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -47383,6 +47662,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ubW" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/wolf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/beach/forest)
 "uca" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/wood,
@@ -48747,6 +49030,19 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"uEw" = (
+/obj/structure/fluff/walldeco/med{
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "uEy" = (
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/cobble,
@@ -48772,6 +49068,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"uFa" = (
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 1
+	},
+/area/rogue/outdoors/beach/forest)
 "uFd" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement)
@@ -49530,6 +49831,9 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"uVt" = (
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "uVN" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -51026,6 +51330,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"vDS" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 6
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/cave)
 "vDV" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
@@ -51068,6 +51379,11 @@
 /obj/item/rogueweapon/hammer,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"vEG" = (
+/turf/open/floor/rogue/greenstone{
+	dir = 1
+	},
+/area/rogue/outdoors/beach/forest)
 "vEO" = (
 /obj/item/rogueweapon/shield/wood/crafted{
 	pixel_y = 32
@@ -51143,6 +51459,12 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"vGh" = (
+/obj/structure/closet/crate/chest/old_crate,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "vGx" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -51802,6 +52124,13 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
+"vUY" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 2
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/cave)
 "vUZ" = (
 /obj/structure/roguemachine/scomm/directional/west,
 /turf/open/floor/rogue/wood/herringbone,
@@ -51810,6 +52139,11 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/cursed_labyrinth)
+"vVd" = (
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/indoors/cave)
 "vVj" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
@@ -52051,6 +52385,9 @@
 /obj/effect/mapping_helpers/access/church,
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/indoors/town/church/chapel)
+"vZY" = (
+/turf/closed/wall/mineral/rogue/stone/window,
+/area/rogue/indoors/cave)
 "waz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -52280,6 +52617,13 @@
 /obj/effect/decal/remains/saiga,
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
+"wgH" = (
+/obj/structure/mineral_door/bars,
+/obj/structure/trap/stun,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "wgL" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -53192,6 +53536,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
+"wCy" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/beach/forest)
 "wCB" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -53756,6 +54106,13 @@
 "wRg" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/woods)
+"wRj" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/cave)
 "wRq" = (
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/dirt/road,
@@ -54692,6 +55049,14 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town/cell)
+"xlZ" = (
+/obj/structure/stairs/stone{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/indoors/cave)
 "xma" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -56393,6 +56758,12 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/shop)
+"yaC" = (
+/obj/structure/bed/rogue/inn/wool,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/outdoors/beach/forest)
 "yaK" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -346321,12 +346692,12 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+oPv
+oPv
+oPv
+oPv
+oPv
 tsB
 tsB
 tsB
@@ -346773,12 +347144,12 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+vlj
+vlj
+vlj
+vlj
+oPv
 tsB
 tsB
 tsB
@@ -347224,14 +347595,14 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+oPv
+vlj
+vlj
+vlj
+vlj
+oPv
+oPv
 tsB
 tsB
 tsB
@@ -347676,14 +348047,14 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+vlj
+vlj
+sMF
+wRj
+vlj
+vlj
+oPv
 tsB
 tsB
 tsB
@@ -348128,14 +348499,14 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+vlj
+vlj
+ggA
+vUY
+vlj
+vlj
+oPv
 tsB
 tsB
 tsB
@@ -348578,18 +348949,18 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+oPv
+oPv
+vlj
+vlj
+cVK
+vDS
+vlj
+vlj
+oPv
+oPv
+oPv
 tsB
 tsB
 tsB
@@ -349030,17 +349401,17 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+gfT
+vlj
+vlj
+vlj
+vlj
+vlj
+vlj
+vlj
+vlj
+vlj
 tsB
 tsB
 tsB
@@ -349482,17 +349853,17 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+gfT
+vlj
+vlj
+vlj
+vlj
+vlj
+vlj
+vlj
+vlj
+vlj
 tsB
 tsB
 tsB
@@ -349934,18 +350305,18 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+oPv
+vVd
+vlj
+oPv
+oPv
+oPv
+oPv
+vVd
+vlj
+oPv
+oPv
 tsB
 tsB
 tsB
@@ -350387,16 +350758,16 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+vVd
+vlj
+oPv
+oPv
+oPv
+oPv
+vVd
+oPv
+oPv
 tsB
 tsB
 tsB
@@ -350839,16 +351210,16 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+vVd
+vlj
+oPv
+vVd
+vVd
+vVd
+vVd
+vlj
+oPv
 qPv
 qPv
 qPv
@@ -351291,20 +351662,20 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-qPv
-qPv
-qPv
-qPv
-qPv
+oPv
+vVd
+vlj
+oPv
+vVd
+vVd
+vVd
+vVd
+vlj
+oPv
+oPv
+oPv
+oPv
+oPv
 qPv
 qPv
 qPv
@@ -351743,20 +352114,20 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-qPv
-qPv
-qPv
-qPv
-qPv
+oPv
+xlZ
+jCq
+oPv
+vVd
+vVd
+vVd
+vVd
+vlj
+lbV
+lbV
+lbV
+lbV
+lbV
 qPv
 qPv
 qPv
@@ -352195,19 +352566,19 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-qPv
-qPv
-qPv
-qPv
+oPv
+oPv
+oPv
+oPv
+vVd
+vVd
+vVd
+vVd
+vlj
+lbV
+lbV
+lbV
+lbV
 qPv
 qPv
 qPv
@@ -352650,25 +353021,25 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+oPv
+oPv
+oPv
+oPv
+oPv
+vlj
+oPv
+oPv
+oPv
+oPv
+qPv
+qPv
+dCq
+dCq
+dCq
+dCq
 qPv
 qPv
 qPv
-qPv
-qPv
-qPv
-dCq
-dCq
-dCq
-dCq
-dCq
-dCq
-dCq
 dCq
 dCq
 qPv
@@ -353103,15 +353474,15 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-qPv
-qPv
-qPv
-qPv
+vVd
+vVd
+vVd
+vVd
+vlj
+oPv
+vVd
+vlj
+oPv
 qPv
 dCq
 dCq
@@ -353555,15 +353926,15 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-qPv
-qPv
-qPv
-qPv
+vVd
+vVd
+vVd
+vVd
+vlj
+vlj
+vVd
+vlj
+oPv
 qPv
 dCq
 dCq
@@ -354006,16 +354377,16 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-qPv
-qPv
-qPv
-qPv
+oPv
+oPv
+oPv
+oPv
+vVd
+vlj
+oPv
+vVd
+vlj
+vZY
 dCq
 dCq
 dCq
@@ -354461,13 +354832,13 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-qPv
-qPv
-qPv
-qPv
+oPv
+oPv
+oPv
+oPv
+oPv
+oPv
+oPv
 dCq
 dCq
 qPv
@@ -354478,8 +354849,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+dCq
+dCq
 dCq
 dCq
 dCq
@@ -354914,11 +355285,11 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-qPv
-qPv
-qPv
+sJx
+sJx
+sJx
+sJx
+sJx
 dCq
 dCq
 dCq
@@ -354928,8 +355299,8 @@ dCq
 dCq
 dCq
 dCq
-qPv
-qPv
+dCq
+dCq
 dCq
 dCq
 dCq
@@ -355370,7 +355741,7 @@ tsB
 qPv
 qPv
 qPv
-qPv
+sJx
 dCq
 qPv
 qPv
@@ -461130,9 +461501,9 @@ gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
+hRy
+hRy
+hRy
 gTH
 gTH
 gTH
@@ -461572,20 +461943,20 @@ gBM
 gTH
 gTH
 gTH
+dCq
+dCq
+dCq
 gTH
 gTH
 gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+lNa
+iFL
+xEG
+xEG
 gTH
 gTH
 gTH
@@ -462022,25 +462393,25 @@ ogs
 gBM
 gBM
 gTH
+dCq
+dCq
+gTH
+gTH
+hRy
+hRy
 gTH
 gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+lNa
+vMR
+vMR
+vMR
+vMR
+lNa
+hRy
 gTH
 gTH
 gTH
@@ -462474,26 +462845,26 @@ ogs
 gBM
 gBM
 gTH
+dCq
+dCq
+gTH
+hRy
+fwS
+hRy
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+dCq
+dCq
+lNa
+vMR
+vMR
+vMR
+vMR
+lNa
+hRy
+fwS
 gTH
 gTH
 gTH
@@ -462926,6 +463297,26 @@ ogs
 gBM
 gBM
 gTH
+dCq
+dCq
+fwS
+hRy
+hRy
+hRy
+hRy
+dCq
+dCq
+dCq
+gTH
+dCq
+lNa
+vMR
+vMR
+vMR
+vMR
+lNa
+hRy
+fwS
 gTH
 gTH
 gTH
@@ -462933,27 +463324,7 @@ gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+ubW
 gTH
 gTH
 gTH
@@ -463378,35 +463749,35 @@ ogs
 gBM
 gBM
 gTH
+dCq
+gTH
+gTH
+hRy
+hRy
+hRy
+hRy
+dCq
+gTH
+gTH
+gTH
+hRy
+lNa
+vMR
+vMR
+vMR
+vMR
+lNa
+hRy
+fwS
 gTH
 gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -463829,37 +464200,37 @@ ogs
 (136,1,4) = {"
 gBM
 gBM
+dCq
+dCq
+gTH
+fwS
+hRy
+fwS
+hRy
+hRy
+fwS
+fwS
+fwS
+fwS
+fwS
+lNa
+vMR
+vMR
+vMR
+vMR
+lNa
+hRy
+hRy
+hRy
+hRy
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -464282,35 +464653,35 @@ ogs
 gBM
 gBM
 gTH
+dCq
 gTH
+fwS
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+nsX
+vMR
+fwS
+lNa
+vMR
+vMR
+vMR
+vMR
+lNa
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+dCq
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -464736,32 +465107,32 @@ gBM
 gTH
 gTH
 gTH
+fwS
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+nsX
+vMR
+fwS
+lNa
+vMR
+vMR
+vMR
+vMR
+lNa
+hRy
+hRy
+hRy
+hRy
+hRy
 gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
 gTH
 gTH
 gTH
@@ -465188,6 +465559,24 @@ gBM
 gTH
 gTH
 gTH
+fwS
+hRy
+fwS
+hRy
+hRy
+fwS
+fwS
+fwS
+fwS
+fwS
+lNa
+xEG
+xEG
+xEG
+xEG
+lNa
+hRy
+fwS
 gTH
 gTH
 gTH
@@ -465195,25 +465584,7 @@ gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
 gTH
 gTH
 gTH
@@ -465640,32 +466011,32 @@ gBM
 gTH
 gTH
 gTH
+fwS
+hRy
+hRy
+hRy
+hRy
+fwS
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+hRy
+fwS
 gTH
 gTH
 gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+ubW
+dCq
 gTH
 gTH
 gTH
@@ -466089,6 +466460,27 @@ ogs
 (141,1,4) = {"
 gBM
 gBM
+fwS
+fwS
+fwS
+fwS
+fwS
+fwS
+fwS
+fwS
+fwS
+hRy
+hRy
+hRy
+hRy
+hRy
+gTH
+gTH
+gTH
+gTH
+dCq
+dCq
+fwS
 gTH
 gTH
 gTH
@@ -466096,29 +466488,8 @@ gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -466541,6 +466912,26 @@ ogs
 (142,1,4) = {"
 gBM
 gBM
+fwS
+tSD
+lSw
+wgH
+lSw
+uEw
+aJD
+vGh
+fwS
+fwS
+fwS
+fwS
+fwS
+fwS
+fwS
+gTH
+gTH
+gTH
+gTH
+dCq
 gTH
 gTH
 gTH
@@ -466550,28 +466941,8 @@ gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
 gTH
 gTH
 vMR
@@ -466993,27 +467364,27 @@ ogs
 (143,1,4) = {"
 gBM
 gBM
+fwS
+bUj
+lSw
+rva
+lSw
+lSw
+lSw
+lSw
+rva
+lSw
+bUj
+fwS
+vMR
+vMR
+fwS
+gTH
+ubW
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -467445,27 +467816,27 @@ ogs
 (144,1,4) = {"
 gBM
 gBM
+fwS
+fwS
+fwS
+fwS
+lKP
+lSw
+lSw
+lSw
+wgH
+lSw
+tSD
+fwS
+mec
+mec
+fwS
+dCq
+dCq
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
 gTH
 gTH
 gTH
@@ -467897,27 +468268,27 @@ ogs
 (145,1,4) = {"
 gBM
 gBM
+fwS
+vGh
+lSw
+fwS
+fwS
+fwS
+duu
+fwS
+fwS
+fwS
+fwS
+fwS
+lSw
+lSw
+fwS
+ubW
+dCq
+dCq
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -467927,8 +468298,8 @@ vMR
 vMR
 vMR
 vMR
-gTH
-gTH
+dCq
+dCq
 gTH
 vMR
 vMR
@@ -468349,26 +468720,26 @@ ogs
 (146,1,4) = {"
 gBM
 gBM
+fwS
+mCg
+lSw
+ngu
+bcM
+lSw
+lSw
+lSw
+lSw
+lSw
+lSw
+lSw
+lSw
+lSw
+fwS
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -468380,8 +468751,8 @@ vMR
 vMR
 vMR
 gTH
-gTH
-gTH
+dCq
+dCq
 gTH
 vMR
 vMR
@@ -468801,25 +469172,26 @@ ogs
 (147,1,4) = {"
 gBM
 gBM
+fwS
+fwS
+fwS
+fwS
+fwS
+lSw
+lSw
+lSw
+lSw
+lSw
+lSw
+lSw
+lSw
+lSw
+fwS
+gTH
+dCq
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
 gTH
 gTH
 gTH
@@ -468830,10 +469202,9 @@ vMR
 vMR
 vMR
 vMR
-vMR
 gTH
 gTH
-gTH
+dCq
 gTH
 gTH
 vMR
@@ -469253,26 +469624,26 @@ ogs
 (148,1,4) = {"
 gBM
 gBM
+fwS
+lSw
+lSw
+lSw
+pGG
+lSw
+fwS
+fwS
+fwS
+fwS
+fwS
+fwS
+lSw
+lSw
+fwS
 gTH
+dCq
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -469285,9 +469656,9 @@ vMR
 vMR
 gTH
 gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+dCq
 gTH
 vMR
 vMR
@@ -469705,39 +470076,39 @@ ogs
 (149,1,4) = {"
 gBM
 gBM
+fwS
+dgd
+lSw
+lSw
+fwS
+fwS
+fwS
+eNd
+uVt
+jVb
+qUh
+fwS
+lSw
+lSw
+fwS
+gTH
+ubW
+dCq
+dCq
+dCq
+dCq
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+fwS
 vMR
 vMR
 vMR
 vMR
 vMR
 vMR
-vMR
-vMR
-vMR
-gTH
+dCq
+dCq
+dCq
 gTH
 vMR
 vMR
@@ -470157,28 +470528,28 @@ ogs
 (150,1,4) = {"
 gBM
 gBM
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+fwS
+vGh
+iTB
+yaC
+fwS
+iJM
+uVt
+uVt
+nzP
+fwS
+uVt
+fwS
+lSw
+lSw
+fwS
+fwS
+fwS
+dCq
+dCq
+dCq
+dCq
+fwS
 gTH
 vMR
 vMR
@@ -470609,28 +470980,28 @@ cxA
 (151,1,4) = {"
 gBM
 gBM
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+fwS
+fwS
+fwS
+fwS
+fwS
+uVt
+uVt
+uVt
+uVt
+qGD
+uVt
+oVo
+lSw
+ebC
+vEG
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+fwS
 vMR
 vMR
 vMR
@@ -471063,26 +471434,26 @@ gBM
 gBM
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+qRS
+rCo
+fwS
+hkO
+uVt
+bib
+ijH
+uVt
+uVt
+cvH
+ebC
+ebC
+dCq
+dCq
+ebC
+dCq
+dCq
+eQQ
+ebC
+sVG
 vMR
 vMR
 vMR
@@ -471515,26 +471886,26 @@ gBM
 gBM
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+eGi
+lNG
+pug
+uVt
+uVt
+uVt
+qGD
+uVt
+cvH
+lSw
+pqX
+fwS
+dCq
+dCq
+dCq
+dCq
+ebC
+ebC
+fwS
 vMR
 vMR
 vMR
@@ -471966,27 +472337,27 @@ cxA
 gBM
 gBM
 gTH
+dCq
+dCq
+uFa
+fwS
+fwS
+aAn
+uVt
+uVt
+fwS
+uVt
+fwS
+lSw
+ebC
+fwS
 gTH
-gTH
-gTH
-vMR
-vMR
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+dCq
+ebC
+fwS
+fwS
 vMR
 vMR
 vMR
@@ -472420,24 +472791,24 @@ gBM
 vMR
 vMR
 vMR
-vMR
-vMR
+pTA
+rCo
+fwS
+fwS
+jVb
+uVt
+qqz
+wCy
+fwS
+ebC
+ebC
+fwS
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+fwS
 vMR
 vMR
 vMR
@@ -472873,16 +473244,16 @@ vMR
 vMR
 vMR
 vMR
-vMR
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+pTA
+rCo
+fwS
+fwS
+rjm
+fwS
+fwS
+fwS
+lSw
+pqX
 gTH
 gTH
 gTH
@@ -473326,14 +473697,14 @@ vMR
 vMR
 vMR
 vMR
-vMR
+pTA
+qRS
+qRS
+iVB
+qRS
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+fwS
+cvH
 gTH
 gTH
 gTH
@@ -473780,12 +474151,12 @@ vMR
 vMR
 vMR
 vMR
+dCq
+dCq
+dCq
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+fwS
+dCq
 gTH
 gTH
 gTH
@@ -474232,12 +474603,12 @@ vMR
 vMR
 vMR
 vMR
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+qOV
+dCq
+lSw
+ebC
 gTH
 gTH
 gTH
@@ -474685,10 +475056,10 @@ vMR
 vMR
 vMR
 vMR
-gTH
-gTH
-gTH
-gTH
+dCq
+dCq
+dCq
+dCq
 gTH
 gTH
 gTH
@@ -475138,7 +475509,7 @@ vMR
 vMR
 vMR
 vMR
-gTH
+dCq
 gTH
 gTH
 gTH

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -200,15 +200,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"aeh" = (
-/obj/structure/stairs/stone{
-	dir = 4
-	},
-/obj/machinery/light/rogue/torchholder/directional/south,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "aen" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -442,11 +433,6 @@
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
-"aiL" = (
-/obj/structure/fluff/statue/knight/interior/r,
-/mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "aiP" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -599,6 +585,13 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"alR" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "amf" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town)
@@ -757,6 +750,10 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"apz" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "apQ" = (
 /obj/machinery/light/small{
 	mouse_opacity = 0;
@@ -1042,14 +1039,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"auT" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "avc" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -1365,6 +1354,15 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
+"aCM" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aCU" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -1418,6 +1416,12 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"aDE" = (
+/obj/machinery/light/rogue/oven/west,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aDQ" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -1505,6 +1509,12 @@
 "aGv" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"aGH" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aGW" = (
 /obj/structure/glowshroom,
 /obj/structure/spacevine,
@@ -1517,10 +1527,6 @@
 	},
 /turf/open/lava/acid,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
-"aHe" = (
-/obj/item/storage/belt/rogue/pouch/coins/rich,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "aHj" = (
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
@@ -1699,12 +1705,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors)
-"aKk" = (
-/mob/living/carbon/human/species/skeleton/npc/no_equipment,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "aKn" = (
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/concrete,
@@ -2149,12 +2149,6 @@
 	dir = 10
 	},
 /area/rogue/outdoors/town/roofs)
-"aSY" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/mole{
-	faction = list("wolfs","undead")
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "aTj" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/clothing/under/roguetown/tights/black,
@@ -2219,13 +2213,6 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
-"aUl" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/food,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "aUm" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -2519,11 +2506,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
-"baC" = (
-/turf/open/floor/rogue/concrete{
-	dir = 4
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "baE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -2629,12 +2611,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
-"bcK" = (
-/obj/structure/fermenting_barrel,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "bcM" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/blocks/green{
@@ -2737,12 +2713,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
-"bfo" = (
-/obj/structure/fluff/statue/knight/interior,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "bfr" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/cobble,
@@ -2751,6 +2721,15 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"bfS" = (
+/obj/machinery/light/rogue/torchholder/directional/south,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bfY" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/ocean,
@@ -2820,12 +2799,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
-"bhv" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "bhB" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/chair/wood/rogue/chair3,
@@ -2926,6 +2899,10 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"bjS" = (
+/obj/machinery/light/rogue/chand,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bjT" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -2963,10 +2940,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
-"bkx" = (
-/obj/structure/fermenting_barrel/sourwine,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "bkK" = (
 /obj/effect/decal/remains/saiga,
 /turf/open/floor/rogue/dirt/road,
@@ -2998,6 +2971,14 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
+"blM" = (
+/obj/machinery/light/rogue/torchholder/directional/east,
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "blW" = (
 /obj/structure/mirror{
 	pixel_y = -32
@@ -3028,12 +3009,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/woods)
-"bmj" = (
-/obj/machinery/light/rogue/torchholder/directional/east,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "bmv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3423,14 +3398,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
-"buk" = (
-/obj/structure/closet/crate/coffin,
-/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "bum" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -3529,6 +3496,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/church/chapel)
+"bvY" = (
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bwv" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
@@ -3600,9 +3572,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"bzl" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "bzq" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -3700,10 +3669,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"bBf" = (
-/obj/structure/fluff/walldeco/chains,
-/turf/open/transparent/openspace,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "bBi" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -3858,6 +3823,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"bDJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bDK" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /turf/open/floor/rogue/ruinedwood/platform,
@@ -4054,6 +4025,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"bHI" = (
+/obj/machinery/light/rogue/torchholder/directional/east,
+/obj/item/cooking/platter,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bHK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -4158,6 +4136,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"bJF" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bJM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/east,
 /turf/open/floor/rogue/herringbone,
@@ -4451,6 +4433,12 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/south,
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/indoors/town/church/chapel)
+"bPD" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bPF" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -4612,6 +4600,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"bSp" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bSu" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/dirt,
@@ -4834,6 +4826,18 @@
 	dir = 1
 	},
 /area/rogue/outdoors/beach)
+"bWg" = (
+/obj/item/chair/rogue/crafted{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
+"bWj" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bWv" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "steward_shutter"
@@ -4914,6 +4918,12 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"bYB" = (
+/obj/machinery/light/rogue/torchholder/directional/south,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bYC" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement/keep)
@@ -5044,6 +5054,14 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach/forest)
+"ccr" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ccw" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/walldeco/church/line{
@@ -5188,6 +5206,15 @@
 /obj/machinery/light/rogue/torchholder/directional/west,
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"cgN" = (
+/obj/item/reagent_containers/glass/mortar,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cgP" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -5649,6 +5676,10 @@
 /obj/structure/bars/passage/shutter/open,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"cro" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "crt" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -5839,12 +5870,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
-"cvb" = (
-/obj/structure/fluff/statue,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "cvG" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -5866,9 +5891,6 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"cwy" = (
-/turf/open/transparent/openspace,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "cwF" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -5905,12 +5927,10 @@
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
-"cxa" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
+"cxf" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks{
-	dir = 8
+	dir = 4
 	},
 /area/rogue/under/cave/dungeon/fort_dusk)
 "cxi" = (
@@ -6446,12 +6466,6 @@
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"cJl" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "cJt" = (
 /obj/structure/rack/rogue,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -6498,6 +6512,10 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/basement)
+"cLb" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/wolf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cLi" = (
 /obj/structure/table/church{
 	icon_state = "churchtable_mid"
@@ -6684,14 +6702,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/vulnafir)
-"cOk" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "cOm" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 8
@@ -7009,12 +7019,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
-"cUW" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "cVh" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -7228,6 +7232,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"cYJ" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cYL" = (
 /obj/effect/decal/remains/saiga,
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
@@ -7411,10 +7419,6 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/winding_halls)
-"ddf" = (
-/obj/structure/fermenting_barrel/murkwine,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "ddr" = (
 /obj/structure/chair/bench/church/mid,
 /turf/open/floor/rogue/concrete,
@@ -7594,15 +7598,6 @@
 /obj/structure/fluff/walldeco/rpainting,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cave/dungeon/abandoned_manor)
-"dhA" = (
-/obj/item/restraints/legcuffs/beartrap,
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "dhP" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/church,
@@ -7695,6 +7690,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"dkw" = (
+/obj/structure/fermenting_barrel/water,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dkC" = (
 /obj/structure/spider/stickyweb{
 	dir = 4;
@@ -7740,15 +7739,6 @@
 "dlW" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors)
-"dmh" = (
-/obj/effect/decal/cleanable/dirt/cobweb,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "dmp" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/cobble,
@@ -7943,6 +7933,14 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/dungeon/licharena)
+"dqw" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/obj/structure/fluff/alch,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dqx" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -8238,6 +8236,15 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"dvS" = (
+/obj/effect/decal/cleanable/dirt/cobweb,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dvU" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -8424,6 +8431,13 @@
 /obj/structure/boatbell/fluff,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach/forest)
+"dAM" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dBb" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road,
@@ -8528,6 +8542,11 @@
 "dDM" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"dDS" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dEi" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/dirt,
@@ -9324,6 +9343,11 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"dUL" = (
+/obj/machinery/light/rogue/torchholder/directional/south,
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dUR" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -9591,13 +9615,6 @@
 /obj/item/reagent_containers/glass/cup/golden,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/dungeon/licharena)
-"dZM" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "dZS" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -9649,12 +9666,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/dwarfin)
-"eaI" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "eaQ" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9678,6 +9689,12 @@
 /obj/item/roguecoin/copper,
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon/old_ruin)
+"ebm" = (
+/obj/structure/fluff/walldeco/chains{
+	icon_state = "chains4"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ebs" = (
 /obj/item/rogueweapon/thresher,
 /turf/open/floor/rogue/dirt/road,
@@ -9867,14 +9884,6 @@
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/winding_halls)
-"egW" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "ehc" = (
 /obj/structure/spider/stickyweb{
 	icon_state = "stickyweb2"
@@ -10110,6 +10119,10 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/north,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/town/basement/keep)
+"ekP" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ekT" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/water/sewer,
@@ -10848,6 +10861,11 @@
 /obj/effect/landmark/start/priest,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"eyP" = (
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/torchholder/directional/north,
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ezd" = (
 /obj/structure/chair/bench{
 	dir = 1
@@ -10907,20 +10925,6 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
-"ezV" = (
-/obj/structure/winch{
-	gid = "bastilletop";
-	redstone_id = "bastilletop";
-	name = "Tsoridys' Mercy"
-	},
-/obj/structure/fluff/walldeco/med5{
-	pixel_x = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "ezW" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -11021,12 +11025,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains)
-"eBC" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "eBE" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/rack/rogue,
@@ -11112,11 +11110,9 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"eDg" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/concrete{
-	dir = 8
-	},
+"eDh" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/green,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "eDp" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -11469,6 +11465,11 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"eKt" = (
+/turf/open/floor/rogue/concrete{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eKv" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -11508,10 +11509,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains)
-"eLG" = (
-/obj/machinery/light/rogue/torchholder/directional/west,
-/turf/open/transparent/openspace,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "eLL" = (
 /obj/item/natural/stone{
 	icon_state = "stone5"
@@ -11920,6 +11917,12 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
+"eTI" = (
+/obj/structure/fluff/walldeco/chains{
+	icon_state = "chains2"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eTN" = (
 /obj/structure/closet/crate/chest{
 	base_icon_state = "woodchestalt";
@@ -11955,19 +11958,16 @@
 /obj/structure/roguemachine/bounty,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"eUn" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "eUq" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
+"eUs" = (
+/obj/structure/fluff/statue/knight/interior,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eUv" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -12167,6 +12167,10 @@
 	dir = 4
 	},
 /area/rogue/indoors/shelter/woods)
+"eYZ" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eZb" = (
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town)
@@ -12648,6 +12652,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"fhV" = (
+/obj/structure/fermenting_barrel/murkwine,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fhY" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -12663,15 +12671,6 @@
 "fii" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/rtfield)
-"fix" = (
-/obj/machinery/light/rogue/torchholder/directional/south,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fiK" = (
 /obj/structure/stairs{
 	dir = 8
@@ -12861,6 +12860,14 @@
 /obj/machinery/light/rogue/torchholder/directional/west,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"fms" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fmu" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/roofs)
@@ -12911,15 +12918,6 @@
 "fnC" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
-"fnG" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fnJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/bog)
@@ -13032,15 +13030,6 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
-"fqu" = (
-/obj/structure/closet/crate/coffin,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fqA" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -13209,17 +13198,16 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
-"fuo" = (
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fus" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"fuJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fuY" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/remains/xeno,
@@ -13269,6 +13257,14 @@
 /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
+"fvH" = (
+/obj/structure/winch{
+	gid = "bastilletop";
+	redstone_id = "bastilletop";
+	name = "Tsoridys' Mercy"
+	},
+/turf/closed/mineral/random/rogue/high,
+/area/rogue/indoors/cave)
 "fvI" = (
 /obj/structure/chair/stool/rogue,
 /obj/structure/fluff/railing/border{
@@ -13500,15 +13496,6 @@
 	dir = 8
 	},
 /area/rogue/under/town/sewer)
-"fAh" = (
-/mob/living/simple_animal/hostile/rogue/dragger,
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fAm" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
@@ -13548,6 +13535,12 @@
 /obj/item/paper,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
+"fBd" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fBm" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/cobblerock,
@@ -13806,6 +13799,13 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
+"fIs" = (
+/obj/structure/table/wood,
+/obj/item/cooking/platter,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fIx" = (
 /obj/effect/decal/wood/herringbone{
 	dir = 4
@@ -13847,12 +13847,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"fJw" = (
-/obj/structure/mineral_door/wood/violet{
-	locked = 1
-	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fJD" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -14053,6 +14047,12 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
+"fOk" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fOn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -14142,14 +14142,6 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
-"fQf" = (
-/obj/item/chair/rogue/crafted{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fQE" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
@@ -14170,6 +14162,19 @@
 /obj/effect/landmark/start/knavewench,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
+"fRf" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
+"fRi" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fRp" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/effect/decal/cobbleedge{
@@ -14445,9 +14450,6 @@
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
-"fWH" = (
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fWS" = (
 /obj/item/flint,
 /obj/structure/table/wood{
@@ -14492,6 +14494,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
+"fXn" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fXp" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -14540,10 +14548,6 @@
 "fYc" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"fYe" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fYi" = (
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/dirt/road,
@@ -14574,14 +14578,6 @@
 /obj/item/rogueweapon/stoneaxe/battle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"fYs" = (
-/obj/item/chair/rogue/crafted{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "fYD" = (
 /obj/item/ash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14894,12 +14890,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"gfg" = (
-/obj/machinery/light/rogue/oven/west,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gfj" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/roguemachine/scomm/directional/north,
@@ -15003,14 +14993,6 @@
 /obj/item/toy/cards/deck/tarot,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"gia" = (
-/obj/structure/closet/crate/coffin,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gij" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/garrison)
@@ -15086,6 +15068,16 @@
 /obj/item/clothing/head/roguetown/helmet,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"gjs" = (
+/obj/item/storage/belt/rogue/pouch/coins/rich,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
+"gjF" = (
+/obj/machinery/light/rogue/torchholder/directional/east,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gjH" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/effect/landmark/start/guardsman{
@@ -15192,17 +15184,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"gms" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gmu" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
+"gmv" = (
+/obj/structure/mineral_door/wood/violet,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gmy" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -15268,6 +15257,15 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/dungeon/winding_halls)
+"goI" = (
+/obj/item/restraints/legcuffs/beartrap,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "goM" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/hexstone,
@@ -15277,6 +15275,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/under/underdark)
+"goQ" = (
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "goU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15450,6 +15455,12 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"gte" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gtp" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
@@ -15534,12 +15545,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"gvf" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gvg" = (
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -16015,6 +16020,15 @@
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
+"gEI" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gEO" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	icon_state = "wooddir";
@@ -16022,11 +16036,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
-"gFf" = (
-/turf/open/floor/rogue/concrete{
-	dir = 1
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gFm" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -16372,11 +16381,6 @@
 /obj/structure/bars/steel,
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
-"gLz" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gLG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
@@ -16399,9 +16403,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains)
-"gLN" = (
-/turf/open/floor/rogue/grassred,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gLW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -16506,11 +16507,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/goblinfort)
-"gPf" = (
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gPh" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -16685,6 +16681,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"gTx" = (
+/obj/machinery/light/rogue/torchholder/directional/south,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gTA" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/naturalstone,
@@ -16701,12 +16701,6 @@
 "gTH" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/beach/forest)
-"gTQ" = (
-/obj/effect/decal/cleanable/dirt/cobweb,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "gTY" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
@@ -17319,6 +17313,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"hep" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hex" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/tile/masonic/spiral,
@@ -17371,20 +17371,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
-"hfU" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/item/reagent_containers/glass/bottle/rogue/elfred,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter{
-	pixel_x = 0;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hfZ" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood,
@@ -17393,14 +17379,6 @@
 /obj/structure/glowshroom,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
-"hgr" = (
-/obj/structure/fluff/railing/border,
-/mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hgH" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/roguegrass,
@@ -17422,12 +17400,6 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
-"hhd" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hhi" = (
 /obj/structure/closet/crate/chest/neu{
 	locked = 1;
@@ -17456,6 +17428,10 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/north,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"hhB" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hhH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -17552,17 +17528,6 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"hjk" = (
-/obj/structure/fluff/statue/small{
-	pixel_x = 0;
-	pixel_y = 14
-	},
-/obj/structure/table/wood,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hjm" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/carpet/red,
@@ -17614,6 +17579,10 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"hkI" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hkO" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 9
@@ -17676,6 +17645,12 @@
 "hmi" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"hmm" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hmq" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -17717,14 +17692,6 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"hmS" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hmU" = (
 /obj/structure/chair/bench/couch/r,
 /turf/open/floor/rogue/hexstone,
@@ -17809,14 +17776,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"hoH" = (
-/obj/machinery/light/rogue/torchholder/directional/east,
-/obj/structure/closet/crate/chest/neu,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hoS" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
@@ -17958,10 +17917,6 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"hsc" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hsg" = (
 /obj/structure/roguemachine/mail/directional/south{
 	mailtag = "Dwarven Quarter"
@@ -18019,10 +17974,6 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
-"hsZ" = (
-/mob/living/simple_animal/hostile/rogue/dragger,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "htl" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -18089,6 +18040,12 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
 /area/rogue/under/town/basement)
+"huO" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "huP" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -18265,12 +18222,6 @@
 "hxX" = (
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/dungeon/goblinfort)
-"hyg" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks{
-	dir = 4
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hyh" = (
 /obj/structure/stairs{
 	dir = 8
@@ -18459,10 +18410,6 @@
 /obj/item/storage/belt/rogue/pouch/coins/rich,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/dungeon/licharena)
-"hBp" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hBy" = (
 /obj/structure/chair/bench/ultimacouch,
 /obj/structure/fluff/walldeco/maidensigil/r,
@@ -18475,6 +18422,12 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"hBM" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hBO" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
@@ -18678,6 +18631,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"hFO" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hFS" = (
 /obj/item/bedsheet/rogue/fabric,
 /obj/structure/bed/rogue/inn/wool,
@@ -18858,11 +18818,6 @@
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"hKx" = (
-/obj/machinery/light/rogue/chand,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/turf/open/transparent/openspace,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hKF" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/ruinedwood{
@@ -19019,19 +18974,9 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
-"hNN" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/glass/bottle{
-	pixel_x = 9;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
+"hNQ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "hNV" = (
 /turf/open/water/cleanshallow,
@@ -19112,10 +19057,6 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
-"hQp" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/wood,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hQq" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -19435,12 +19376,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"hWC" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "hWO" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -19855,10 +19790,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
-"iei" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassred,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "ien" = (
 /obj/structure/bars/passage/shutter,
 /turf/open/floor/rogue/dirt/road,
@@ -19953,6 +19884,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/dungeon/vulnafir)
+"igp" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/beach/forest)
 "igs" = (
 /obj/item/grown/log/tree/small,
 /mob/living/carbon/human/species/skeleton/npc,
@@ -20007,6 +19942,12 @@
 /obj/structure/mineral_door/wood/violet,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"ihR" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ihS" = (
 /obj/structure/fluff/wallclock/directional/north,
 /turf/open/floor/rogue/church,
@@ -20355,9 +20296,9 @@
 /obj/structure/table/vtable,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/dungeon/winding_halls)
-"ioP" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/wolf,
-/turf/open/floor/rogue/dirt,
+"ioM" = (
+/obj/item/storage/belt/rogue/pouch/coins/poor,
+/turf/open/floor/rogue/blocks/green,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "ipd" = (
 /obj/structure/flora/roguetree/burnt,
@@ -20409,15 +20350,6 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"iqj" = (
-/obj/item/reagent_containers/glass/mortar,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "iqx" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/naturalstone,
@@ -20508,12 +20440,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
-"irB" = (
-/obj/item/roguegem/random,
-/turf/open/floor/rogue/concrete{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "irI" = (
 /obj/structure/bars/pipe,
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -20702,15 +20628,6 @@
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/indoors/cave)
-"iwp" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "iwF" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
@@ -20732,10 +20649,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"iwR" = (
-/obj/machinery/light/rogue/torchholder/directional/south,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "iwT" = (
 /obj/machinery/light/roguestreet{
 	dir = 1
@@ -21136,12 +21049,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/shop)
-"iDX" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/concrete{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "iDZ" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town/tavern)
@@ -21241,6 +21148,14 @@
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"iGu" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iGF" = (
 /obj/structure/roguerock,
 /turf/open/water/river{
@@ -21438,16 +21353,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"iLc" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/stampot,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "iLf" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains7"
@@ -22519,10 +22424,6 @@
 /obj/structure/closet/crate/drawer/random,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"jff" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "jfh" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -22570,6 +22471,16 @@
 /obj/effect/decal/wood/herringbone2,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
+"jfS" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jfX" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -22631,6 +22542,9 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"jhC" = (
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jhF" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -22727,12 +22641,6 @@
 /obj/item/paper/scroll,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"jiW" = (
-/obj/machinery/light/rogue/torchholder/directional/west,
-/turf/open/floor/rogue/blocks{
-	dir = 4
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "jiY" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	icon_state = "iron_corner";
@@ -22871,6 +22779,12 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/winding_halls)
+"jmP" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jmR" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
@@ -22933,6 +22847,10 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"joc" = (
+/obj/effect/decal/remains/wolf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/beach/forest)
 "jon" = (
 /obj/structure/roguemachine/scomm/directional/south,
 /turf/open/floor/rogue/carpet,
@@ -23131,6 +23049,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"jsF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jsG" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -23547,6 +23471,11 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"jCG" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jCN" = (
 /obj/structure/spacevine,
 /obj/structure/mineral_door/wood/deadbolt{
@@ -23680,14 +23609,6 @@
 "jFA" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
-"jFO" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave/dungeon/fort_dusk)
-"jFW" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "jGl" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -23923,17 +23844,6 @@
 "jKY" = (
 /turf/open/water/sewer,
 /area/rogue/outdoors/mountains/decap)
-"jLb" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "jLl" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/structure/fluff/railing/border{
@@ -24545,6 +24455,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"jYO" = (
+/obj/structure/fluff/statue/knight/interior,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jYP" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains)
@@ -24936,10 +24850,6 @@
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
-"khZ" = (
-/obj/structure/fluff/statue/knight/interior,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "kil" = (
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
@@ -25277,10 +25187,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"krm" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "krw" = (
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/town/roofs)
@@ -25868,6 +25774,13 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/dungeon/licharena)
+"kDl" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/food,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kDC" = (
 /obj/structure/stairs{
 	dir = 4
@@ -25933,6 +25846,12 @@
 "kEY" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/cave)
+"kFd" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kFe" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -25943,16 +25862,6 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
-"kFr" = (
-/obj/structure/mineral_door/wood/violet,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
-"kFB" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "kFC" = (
 /obj/structure/closet/crate/chest/lootbox,
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/east,
@@ -26519,6 +26428,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter/woods)
+"kQp" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kQB" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
@@ -26674,6 +26590,12 @@
 /obj/item/quiver/bolts,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"kTq" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kTC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/blocks/platform,
@@ -26726,6 +26648,14 @@
 /obj/structure/gravemarker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"kVp" = (
+/obj/structure/fluff/railing/border,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kVu" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road,
@@ -26905,6 +26835,14 @@
 /obj/item/clothing/cloak/half,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"kYG" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kYM" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/naturalstone,
@@ -26922,12 +26860,6 @@
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"kZp" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/concrete{
-	dir = 4
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "kZu" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -26983,6 +26915,18 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"laN" = (
+/obj/structure/table/wood,
+/obj/item/cooking/platter{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = -6;
+	pixel_y = 15
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "laP" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/table/wood{
@@ -27093,6 +27037,12 @@
 	icon_state = "glyph6"
 	},
 /area/rogue/indoors/town/vault)
+"lda" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ldf" = (
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/dirt/road,
@@ -27371,10 +27321,6 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
-"lip" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "liq" = (
 /obj/item/chair/rogue{
 	dir = 1
@@ -27537,6 +27483,14 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"lmn" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lmt" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/dungeon/licharena)
@@ -27684,10 +27638,6 @@
 	dir = 4
 	},
 /area/rogue/under/town/basement)
-"loH" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "loK" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/huntingknife/idagger,
@@ -27797,12 +27747,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
-"lqL" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/blocks{
-	dir = 4
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "lqM" = (
 /obj/structure/closet/crate/drawer/random,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -27843,10 +27787,6 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"lrX" = (
-/obj/structure/fermenting_barrel/beer,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "lrZ" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/cobble/mossy,
@@ -27943,6 +27883,10 @@
 /obj/item/roguecoin/copper,
 /turf/open/water/cleanshallow,
 /area/rogue/under/cave/dungeon/vulnafir)
+"ltM" = (
+/mob/living/simple_animal/hostile/rogue/dragger,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ltQ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -27966,6 +27910,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/dungeon/abandoned_manor)
+"lup" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "luA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/railing/fence{
@@ -28227,11 +28175,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
-"lAA" = (
-/turf/open/floor/rogue/concrete{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "lAE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -28262,6 +28205,15 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
+"lBo" = (
+/mob/living/simple_animal/hostile/rogue/dragger,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lBp" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/carpet/lord/right,
@@ -28317,6 +28269,10 @@
 /obj/item/clothing/neck/roguetown/psicross/cinella,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/under/cave/dungeon/old_ruin)
+"lCs" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lCt" = (
 /obj/structure/roguewindow,
 /turf/open/transparent/openspace,
@@ -28854,7 +28810,7 @@
 /area/rogue/outdoors/mountains/decap)
 "lNG" = (
 /obj/structure/stone_tile/slab/cracked,
-/turf/closed,
+/turf/open/floor/rogue/grassred,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "lNY" = (
 /obj/structure/bars/passage/shutter{
@@ -29018,14 +28974,6 @@
 "lRv" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"lRB" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "lRE" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/greenstone,
@@ -29047,6 +28995,12 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/spider,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dungeon/old_ruin)
+"lRU" = (
+/obj/item/roguegem/random,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lRY" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -29178,6 +29132,12 @@
 "lVa" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
 /area/rogue/indoors/shelter/mountains)
+"lVn" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lVr" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/decal/cobbleedge{
@@ -29281,12 +29241,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
-"lXQ" = (
-/obj/machinery/light/rogue/torchholder/directional/west,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "lXR" = (
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -29297,9 +29251,6 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"lYg" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "lYo" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/blocks,
@@ -29596,6 +29547,7 @@
 /obj/structure/stairs/stone{
 	dir = 4
 	},
+/obj/machinery/light/rogue/torchholder/directional/south,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
@@ -29643,6 +29595,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
+"mfp" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mfH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -29739,6 +29697,12 @@
 "mhT" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/indoors/cave)
+"mhU" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mhV" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -29789,10 +29753,6 @@
 "miP" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/sewer)
-"miT" = (
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grassred,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mjd" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -29896,11 +29856,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
-"mma" = (
-/obj/structure/table/wood,
-/obj/item/cooking/platter,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mmb" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /turf/open/floor/rogue/tile{
@@ -30106,11 +30061,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
-"mqa" = (
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mqi" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -30192,16 +30142,6 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
-"mss" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "msF" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -30393,6 +30333,14 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"mwM" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mwW" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -30668,12 +30616,6 @@
 "mCH" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"mCL" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mCR" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
 	pixel_y = 32
@@ -30693,10 +30635,6 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/old_ruin)
-"mDu" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mDy" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 1;
@@ -30750,6 +30688,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/dungeon/vulnafir)
+"mFj" = (
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mFl" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/church,
@@ -30795,12 +30740,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
-"mGK" = (
-/obj/structure/fluff/walldeco/chains{
-	icon_state = "chains4"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mGR" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/swamp/deep,
@@ -30828,12 +30767,6 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"mHd" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mHj" = (
 /obj/structure/bars/pipe{
 	dir = 1;
@@ -30959,13 +30892,6 @@
 "mJH" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
-"mKu" = (
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/machinery/tanningrack,
-/turf/open/floor/rogue/blocks{
-	dir = 4
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mKy" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -31029,13 +30955,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
-"mLS" = (
-/obj/structure/closet/crate/coffin,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mMi" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/dirt,
@@ -31208,11 +31127,6 @@
 "mPn" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon/winding_halls)
-"mPo" = (
-/obj/structure/fluff/statue/knight/interior,
-/mob/living/simple_animal/hostile/rogue/skeleton/bow,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mPv" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -31406,13 +31320,6 @@
 /obj/machinery/anvil/crafted,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
-"mUr" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/structure/closet/crate/chest/neu,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/item/reagent_containers/glass/bottle/rogue/strongpoison,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "mUu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -31428,6 +31335,15 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
+"mUD" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mUI" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/water/swamp,
@@ -31599,6 +31515,14 @@
 	dir = 8
 	},
 /area/rogue/under/cave/dungeon/vulnafir)
+"mXZ" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mYh" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -31809,6 +31733,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
+"naD" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "naO" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -31961,6 +31891,14 @@
 	dir = 8
 	},
 /area/rogue/indoors/shelter/woods)
+"ndN" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ndP" = (
 /obj/structure/chair/stool/rogue,
 /mob/living/carbon/human/species/goblin/npc/ambush,
@@ -32029,12 +31967,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/basement)
-"nfl" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "nfq" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -32206,6 +32138,20 @@
 "niG" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
+"niH" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/glass/bottle{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "niO" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/under/cave/dungeon/vulnafir)
@@ -32297,12 +32243,6 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
-"nkb" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks{
-	dir = 4
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "nkf" = (
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood{
@@ -32499,6 +32439,9 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"nnU" = (
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nnW" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -32528,6 +32471,12 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cave/dungeon/winding_halls)
+"noj" = (
+/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nov" = (
 /obj/item/roguegem,
 /obj/item/roguegem,
@@ -32827,14 +32776,6 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
-"ntT" = (
-/obj/structure/mineral_door/wood/violet{
-	locked = 1
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "ntV" = (
 /obj/structure/roguemachine/scomm/directional/south,
 /turf/open/floor/rogue/ruinedwood{
@@ -32962,6 +32903,11 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/woods)
+"nwV" = (
+/turf/open/floor/rogue/concrete{
+	dir = 1
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nwZ" = (
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -33206,12 +33152,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
-"nBH" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "nBI" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /obj/item/burial_shroud{
@@ -33752,6 +33692,17 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"nNV" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nOh" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/underdark)
@@ -33850,10 +33801,6 @@
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
-"nPj" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "nPk" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -33871,6 +33818,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/dungeon/vulnafir)
+"nPZ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nQt" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/south,
 /turf/open/water/bath,
@@ -33901,6 +33854,20 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"nQT" = (
+/obj/structure/winch{
+	gid = "bastilletop";
+	redstone_id = "bastilletop";
+	name = "Tsoridys' Mercy"
+	},
+/obj/structure/fluff/walldeco/med5{
+	pixel_x = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nRd" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt/road,
@@ -33938,6 +33905,10 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
+"nRS" = (
+/obj/item/chair/rogue/fancy,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nSk" = (
 /obj/structure/fluff/sellsign{
 	name = "WARNING: UNSTABLE LAVA FLOES"
@@ -34046,14 +34017,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"nUe" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
-/obj/machinery/light/rogue/torchholder/directional/east,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "nUf" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grassred,
@@ -34074,14 +34037,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
-"nUx" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "nUL" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt/road,
@@ -34107,6 +34062,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/shelter)
+"nVv" = (
+/obj/item/reagent_containers/glass/bucket/wooden{
+	pixel_x = -1;
+	pixel_y = 12
+	},
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nVC" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -34163,6 +34128,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"nWC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nWE" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/blocks,
@@ -34436,16 +34405,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
-"odt" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave/dungeon/fort_dusk)
-"ody" = (
-/obj/structure/mineral_door/wood/violet{
-	locked = 1
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "odR" = (
 /obj/structure/closet/crate/drawer/random{
 	pixel_y = 0
@@ -35078,6 +35037,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
+"orX" = (
+/obj/structure/bed/rogue/inn/wool,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "osb" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
@@ -35092,14 +35057,6 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"osg" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "oso" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newbranch/leafless,
@@ -35181,6 +35138,12 @@
 "ouj" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/woods)
+"ouk" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oum" = (
 /obj/structure/bars/pipe{
 	dir = 4
@@ -35207,6 +35170,15 @@
 /mob/living/carbon/human/species/elf/dark/drowraider,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdark)
+"ouC" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ouE" = (
 /obj/structure/chair/arrestchair,
 /turf/open/floor/rogue/concrete,
@@ -35588,12 +35560,6 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/abandoned_manor)
-"oBJ" = (
-/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "oBL" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/table/wood{
@@ -35648,6 +35614,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
+"oDz" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/concrete{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oDA" = (
 /obj/structure/fermenting_barrel/crafted,
 /turf/open/floor/rogue/ruinedwood{
@@ -35676,12 +35648,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"oDE" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/concrete{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "oDG" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/fluff/clock,
@@ -35780,10 +35746,6 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
-"oFV" = (
-/obj/structure/roguerock,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "oFY" = (
 /mob/living/simple_animal/hostile/rogue/dragger,
 /turf/open/floor/rogue/dirt,
@@ -35871,15 +35833,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
-"oHb" = (
-/obj/item/restraints/legcuffs/beartrap,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "oHg" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/newbranch/leafless{
@@ -35991,6 +35944,12 @@
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"oKD" = (
+/obj/structure/mineral_door/wood/violet,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oKQ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
@@ -36000,18 +35959,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
-"oKT" = (
-/obj/machinery/light/rogue/torchholder/directional/north,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "oLh" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town)
+"oLj" = (
+/obj/effect/decal/remains/wolf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oLl" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/candle/yellow,
@@ -36261,10 +36218,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"oRi" = (
-/obj/machinery/light/rogue/chand,
-/turf/open/transparent/openspace,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "oRp" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -36329,14 +36282,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/dungeon/winding_halls)
-"oSK" = (
-/obj/machinery/light/rogue/torchholder/directional/north,
-/obj/structure/fluff/alch,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "oSW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -36443,6 +36388,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"oVu" = (
+/obj/item/roguegem/random,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oVv" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
@@ -37203,10 +37152,6 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark)
-"plf" = (
-/obj/structure/mineral_door/wood/violet,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "plg" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/dirt,
@@ -37281,6 +37226,10 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"pnI" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pnQ" = (
 /obj/structure/lever/wall{
 	redstone_id = "mazedungeonrest"
@@ -37349,15 +37298,6 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
-"poC" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "poD" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/minotaur/axe,
 /turf/open/floor/rogue/cobblerock,
@@ -37481,6 +37421,15 @@
 "pqX" = (
 /turf/open/floor/rogue/blocks/green{
 	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
+"prj" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
 	},
 /area/rogue/under/cave/dungeon/fort_dusk)
 "prq" = (
@@ -38054,6 +38003,12 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"pBW" = (
+/obj/structure/fluff/statue,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pBX" = (
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/cobble,
@@ -38199,6 +38154,13 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
+"pFp" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/item/reagent_containers/glass/bottle/rogue/strongpoison,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pFq" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -38350,9 +38312,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/garrison)
-"pIz" = (
-/turf/closed/mineral/random/rogue/med,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "pIB" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -38407,12 +38366,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
-"pJh" = (
-/obj/structure/fluff/walldeco/chains{
-	icon_state = "chains2"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "pJn" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/blocks/newstone,
@@ -38599,6 +38552,17 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"pNY" = (
+/obj/structure/fluff/statue/small{
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/obj/structure/table/wood,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pOh" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -38754,14 +38718,6 @@
 	},
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/town/basement)
-"pQV" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "pQZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -38859,12 +38815,6 @@
 "pSz" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
-"pSI" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "pSN" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -38946,10 +38896,6 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"pUy" = (
-/obj/item/chair/rogue/fancy,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "pUD" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt/road,
@@ -38987,6 +38933,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/goblinfort)
+"pVl" = (
+/obj/structure/roguerock,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pVB" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -39006,6 +38956,13 @@
 "pWh" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cave/dungeon/old_ruin)
+"pWk" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pWp" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -39143,10 +39100,6 @@
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"qas" = (
-/obj/item/storage/belt/rogue/pouch/coins/mid,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qaH" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
@@ -39272,6 +39225,11 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
+"qeo" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qeF" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -39412,6 +39370,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/dungeon/old_ruin)
+"qgT" = (
+/obj/structure/stairs/stone{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qhh" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
@@ -39651,10 +39617,6 @@
 /obj/item/clothing/under/roguetown/chainlegs/iron,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"qlS" = (
-/obj/machinery/light/rogue/torchholder/directional/north,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qmd" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -39740,12 +39702,6 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
-"qog" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/turf/open/floor/rogue/concrete{
-	dir = 4
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qok" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -39785,6 +39741,9 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/church/chapel)
+"qoE" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qpd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/cudgel,
@@ -39809,6 +39768,20 @@
 /obj/structure/plasticflaps,
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
+"qpN" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qpU" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -39974,14 +39947,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
-"qte" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qti" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/beach)
@@ -40104,9 +40069,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"qwd" = (
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qwj" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -40315,20 +40277,18 @@
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dungeon/vulnafir)
-"qAr" = (
-/obj/structure/winch{
-	gid = "bastilletop";
-	redstone_id = "bastilletop";
-	name = "Tsoridys' Mercy"
-	},
-/turf/closed/mineral/random/rogue/high,
-/area/rogue/indoors/cave)
 "qAu" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"qAB" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/concrete{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qAJ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/herringbone,
@@ -40420,13 +40380,9 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/town/sewer)
-"qCJ" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
+"qCM" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/grassred,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "qCP" = (
 /obj/structure/stairs{
@@ -40647,8 +40603,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/dungeon/abandoned_manor)
 "qGD" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/grassred,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
 /area/rogue/under/cave/dungeon/fort_dusk)
 "qGE" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
@@ -40730,14 +40687,6 @@
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dungeon/old_ruin)
-"qHT" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qHZ" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -40915,12 +40864,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"qKL" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qKX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -40990,12 +40933,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"qMM" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qMS" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /turf/open/floor/rogue/herringbone,
@@ -41183,6 +41120,12 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"qRd" = (
+/obj/item/chair/rogue/crafted,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qRo" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -41350,14 +41293,18 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"qVM" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qVX" = (
 /obj/item/grown/log/tree/stake,
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
-"qWj" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qWm" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/carpet/stellar,
@@ -41468,14 +41415,18 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/old_ruin)
+"qYJ" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qYK" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
-"qZe" = (
-/obj/machinery/light/rogue/torchholder/directional/south,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "qZo" = (
 /turf/open/water/river{
 	icon_state = "rockwd"
@@ -41800,6 +41751,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"rga" = (
+/mob/living/carbon/human/species/skeleton/npc/no_equipment,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rgb" = (
 /obj/structure/fluff/walldeco/bsmith{
 	dir = 1
@@ -41994,8 +41951,7 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
 "rjm" = (
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/floor/rogue/grassred,
+/turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "rjo" = (
 /obj/structure/bars/passage/shutter{
@@ -42050,6 +42006,15 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
+"rkY" = (
+/obj/item/restraints/legcuffs/beartrap,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rlm" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/effect/decal/herringbone{
@@ -42074,11 +42039,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"rlM" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rlQ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -42089,12 +42049,6 @@
 "rlV" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/shelter/woods)
-"rlY" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/bow,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rmc" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -42256,6 +42210,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"roY" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rpa" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grass,
@@ -42388,6 +42348,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"rri" = (
+/obj/structure/fluff/statue/knight/interior,
+/mob/living/simple_animal/hostile/rogue/skeleton/bow,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rrl" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -42668,12 +42633,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
-"rxf" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rxg" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
@@ -42757,6 +42716,12 @@
 /obj/machinery/light/rogue/torchholder/directional/south,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
+"rzm" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rzo" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = 32
@@ -42798,6 +42763,13 @@
 "rzU" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"rzW" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rAy" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 1
@@ -43268,10 +43240,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"rJv" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rJz" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/shelter)
@@ -43628,18 +43596,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"rRA" = (
-/obj/structure/mineral_door/wood/violet,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rRD" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"rRI" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rRP" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
@@ -43659,13 +43619,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"rSd" = (
-/obj/structure/table/wood,
-/obj/item/cooking/platter,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rSg" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/hexstone,
@@ -43726,14 +43679,6 @@
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
-"rTt" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rTB" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt/road,
@@ -43806,10 +43751,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/shop)
-"rUT" = (
-/obj/effect/decal/remains/wolf,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "rUU" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -44199,15 +44140,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/cave/dungeon/vulnafir)
-"ses" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sev" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -44252,6 +44184,9 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"sfi" = (
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sfl" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town/roofs)
@@ -44290,12 +44225,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
-"sgq" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sgU" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/indoors/shelter/woods)
@@ -44547,6 +44476,11 @@
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
+"slv" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "slw" = (
 /obj/structure/closet/crate/chest,
 /obj/effect/decal/cobbleedge{
@@ -44727,6 +44661,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"snX" = (
+/obj/machinery/light/rogue/torchholder/directional/west,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "soc" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -44877,6 +44815,9 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"sqF" = (
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sqG" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 4;
@@ -45140,12 +45081,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"sxD" = (
-/obj/structure/table/optable,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sxT" = (
 /turf/closed/wall/mineral/rogue/decostone/end,
 /area/rogue/indoors/town)
@@ -45271,6 +45206,11 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
+"sAi" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sAq" = (
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/cobblerock,
@@ -45348,6 +45288,9 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
+"sCn" = (
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sCo" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -45384,16 +45327,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
-"sDo" = (
-/obj/structure/mineral_door/wood/violet{
-	locked = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sDz" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/north,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church/chapel)
+"sDF" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sDU" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -45526,12 +45471,6 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"sHz" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sHF" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -45593,11 +45532,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
-"sJe" = (
-/obj/structure/fluff/railing/border,
-/obj/machinery/light/rogue/torchholder/directional/north,
-/turf/open/floor/rogue/wood,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sJf" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -45655,16 +45589,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"sKy" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bucket/pot{
-	pixel_x = 1;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sKB" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -45732,11 +45656,6 @@
 "sLn" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"sLv" = (
-/obj/structure/fluff/statue/knight/interior/r,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sLV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -45831,12 +45750,6 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
-"sNB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sNZ" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
@@ -46161,7 +46074,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
 "sVG" = (
-/turf/closed/wall/mineral/rogue/stone/window,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "sVK" = (
 /turf/open/floor/rogue/hay,
@@ -46248,14 +46161,6 @@
 /obj/structure/fluff/walldeco/barbersignreverse,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/town)
-"sYF" = (
-/obj/structure/bed/rogue/shit{
-	name = "makeshift bed"
-	},
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "sYM" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -46357,10 +46262,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
-"tav" = (
-/obj/item/storage/belt/rogue/pouch/coins/poor,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "taz" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -46523,6 +46424,10 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"teD" = (
+/obj/item/storage/belt/rogue/pouch/coins/mid,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "teI" = (
 /obj/structure/chair/bench/coucha/r,
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
@@ -47508,6 +47413,16 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"tBP" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tCa" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/dirt/road,
@@ -47657,6 +47572,10 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tFr" = (
+/obj/structure/mineral_door/wood/violet,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tFx" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -47948,9 +47867,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
-"tLg" = (
-/obj/machinery/light/rogue/torchholder/directional/north,
-/turf/open/floor/rogue/blocks,
+"tLm" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
 /area/rogue/under/cave/dungeon/fort_dusk)
 "tLu" = (
 /turf/closed/mineral/rogue/bedrock,
@@ -48107,12 +48030,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
-"tOA" = (
-/obj/structure/bed/rogue/inn/wool,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "tOB" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/outdoors/town)
@@ -48151,6 +48068,16 @@
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"tPQ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bucket/pot{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tQd" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood,
@@ -48243,7 +48170,6 @@
 /obj/structure/bed/rogue/shit{
 	name = "makeshift bed"
 	},
-/obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
@@ -48284,13 +48210,6 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"tTc" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "tTf" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
@@ -48425,6 +48344,14 @@
 /obj/item/clothing/cloak/apron/brown,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
+"tVN" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tVQ" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /obj/effect/decal/cleanable/blood/old,
@@ -48669,6 +48596,10 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tZX" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uam" = (
 /obj/structure/roguemachine/merchantvend,
 /obj/machinery/light/rogue/wallfire/candle/directional/north,
@@ -48980,6 +48911,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap)
+"uhi" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uhn" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -49251,6 +49188,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"ulV" = (
+/obj/structure/table/optable,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ume" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -49323,6 +49266,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/trollbog,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"unI" = (
+/obj/structure/mineral_door/wood/violet,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "unR" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
 	dir = 1
@@ -49418,6 +49365,11 @@
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
+"upV" = (
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uqi" = (
 /obj/structure/bars/steel,
 /obj/structure/bars/pipe,
@@ -49531,12 +49483,6 @@
 "usY" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/winding_halls)
-"utc" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "utf" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -50018,6 +49964,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
+"uCS" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uDa" = (
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/ruinedwood{
@@ -50422,6 +50372,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"uLr" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uLv" = (
 /obj/structure/well,
 /turf/open/floor/rogue/cobble,
@@ -50503,12 +50457,6 @@
 /obj/structure/roguemachine/scomm/directional/west,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
-"uNe" = (
-/obj/machinery/light/rogue/torchholder/directional/south,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "uNj" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -50772,6 +50720,11 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"uSz" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uSK" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
@@ -50889,7 +50842,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "uVt" = (
-/obj/structure/flora/roguegrass/herb/rosa,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "uVN" = (
@@ -50928,6 +50881,12 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"uWJ" = (
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uWS" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
@@ -51106,6 +51065,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
+"vab" = (
+/obj/machinery/light/rogue/torchholder/directional/west,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vad" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road,
@@ -51175,6 +51140,12 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/goblinfort)
+"vbj" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vbn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -51242,6 +51213,10 @@
 /obj/machinery/light/rogue/torchholder/directional/west,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
+"vbS" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vbV" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -51343,6 +51318,10 @@
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
+"veG" = (
+/obj/structure/fluff/walldeco/chains,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "veW" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border{
@@ -51444,13 +51423,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"vhA" = (
-/obj/machinery/light/rogue/torchholder/directional/east,
-/obj/item/cooking/platter,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "vhE" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -51745,6 +51717,12 @@
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"vnU" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vnW" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/north,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -51796,6 +51774,14 @@
 "voH" = (
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/mountains/decap)
+"voQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "voT" = (
 /obj/structure/chair/bench/church/smallbench{
 	dir = 1
@@ -52006,6 +51992,14 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/basement)
+"vuG" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
+/obj/machinery/light/rogue/torchholder/directional/east,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vuQ" = (
 /obj/effect/decal/remains/cow,
 /turf/open/floor/rogue/dirt/road,
@@ -52569,6 +52563,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/dungeon/licharena)
+"vHl" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vHm" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -52584,6 +52585,20 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
+"vHN" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
+"vHQ" = (
+/obj/machinery/light/rogue/torchholder/directional/west,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vHT" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/churchmarble,
@@ -53000,12 +53015,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"vRr" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "vRF" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road,
@@ -53242,6 +53251,12 @@
 "vVX" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs/keep)
+"vWe" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vWm" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -53255,12 +53270,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"vWv" = (
-/obj/structure/mineral_door/wood/violet,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "vWC" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/beach/forest)
@@ -53467,7 +53476,7 @@
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/indoors/town/church/chapel)
 "vZY" = (
-/turf/closed/wall/mineral/rogue/stonebrick,
+/turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "waz" = (
 /obj/structure/table/wood{
@@ -53872,6 +53881,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"wjI" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wjO" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/wood,
@@ -53903,6 +53919,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
+"wks" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wkv" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -54252,12 +54274,6 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"wsC" = (
-/obj/item/chair/rogue/crafted,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "wsD" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/head/roguetown/roguehood/black,
@@ -54411,13 +54427,6 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"wvA" = (
-/obj/structure/closet/crate/coffin,
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "wvC" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
@@ -54425,13 +54434,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/old_ruin)
-"wvO" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "wvP" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -54591,11 +54593,6 @@
 /obj/effect/mapping_helpers/access/garrison/armory,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"wAW" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "wBc" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/east,
 /turf/open/floor/rogue/hexstone,
@@ -54967,10 +54964,6 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
-"wJW" = (
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/beach/forest)
 "wKc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/concrete{
@@ -55042,10 +55035,6 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/abandoned_manor)
-"wNn" = (
-/obj/item/roguegem/random,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "wNv" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/town/basement)
@@ -55181,12 +55170,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"wQI" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave/dungeon/fort_dusk)
 "wQO" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -55353,12 +55336,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/basement)
-"wUP" = (
-/obj/structure/fluff/statue/knight/interior/r,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "wVh" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/tile,
@@ -55380,14 +55357,6 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
-"wVY" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "wWh" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -55436,6 +55405,12 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"wYa" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wYl" = (
 /obj/structure/flora/roguegrass/maneater,
 /obj/structure/flora/newtree,
@@ -55496,6 +55471,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"wZA" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wZJ" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/platform,
@@ -55565,12 +55546,6 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains)
-"xas" = (
-/mob/living/simple_animal/hostile/rogue/skeleton,
-/turf/open/floor/rogue/blocks/green{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "xaA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -55663,12 +55638,6 @@
 "xcv" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/town/basement)
-"xcw" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "xcz" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/roguebag{
@@ -56191,13 +56160,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"xlS" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "xlY" = (
 /obj/structure/toilet,
 /obj/effect/decal/cobbleedge{
@@ -56309,6 +56271,12 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/dungeon/licharena)
+"xnW" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/bow,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xnZ" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -56337,6 +56305,14 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
+"xoz" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xoB" = (
 /obj/structure/table/church/m,
 /obj/item/reagent_containers/glass/cup/golden{
@@ -56466,6 +56442,15 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"xqz" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xqS" = (
 /obj/structure/fermenting_barrel/water,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -56651,13 +56636,6 @@
 /obj/machinery/light/rogue/torchholder/directional/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"xuW" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "xvm" = (
 /obj/structure/curtain/bounty{
 	color = "grey"
@@ -56776,6 +56754,15 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"xyl" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xyo" = (
 /obj/effect/decal/cobble/mossy{
 	dir = 8
@@ -57248,6 +57235,14 @@
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/woods)
+"xIW" = (
+/obj/item/chair/rogue/crafted{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xIX" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /obj/effect/decal/cobbleedge{
@@ -57275,13 +57270,6 @@
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"xJR" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
-/area/rogue/under/cave/dungeon/fort_dusk)
 "xJW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -57290,6 +57278,12 @@
 	icon_state = "plating2"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"xKf" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xKi" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -57317,6 +57311,12 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter)
+"xLf" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xLB" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road,
@@ -57386,6 +57386,10 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church/chapel)
+"xNv" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xNI" = (
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/floor/rogue/woodturned,
@@ -57438,6 +57442,14 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"xOs" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xOt" = (
 /obj/structure/bookcase/random/archive{
 	opacity = 0
@@ -57453,6 +57465,11 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/north,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"xOB" = (
+/obj/machinery/light/rogue/chand,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xOE" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains5"
@@ -57485,10 +57502,6 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
-"xPa" = (
-/obj/effect/decal/remains/wolf,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/beach/forest)
 "xPc" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/naturalstone,
@@ -58550,6 +58563,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
+"ylu" = (
+/obj/structure/fermenting_barrel/sourwine,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ylw" = (
 /obj/machinery/light/rogue/torchholder/directional/east,
 /obj/structure/bookcase/random,
@@ -58561,6 +58578,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"ylK" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mole{
+	faction = list("wolfs","undead")
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ymd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -117784,13 +117807,13 @@ uXv
 ujm
 ujm
 onF
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
 onF
 onF
 onF
@@ -118236,13 +118259,13 @@ uXv
 ujm
 ujm
 onF
-vZY
-jFO
-lAA
-gFf
-qog
-jFO
-vZY
+sVG
+tZX
+upV
+nwV
+qAB
+tZX
+sVG
 onF
 onF
 onF
@@ -118688,13 +118711,13 @@ uXv
 ujm
 ujm
 onF
-vZY
-oDE
-qwd
-irB
-gFf
-kZp
-vZY
+sVG
+fRi
+jhC
+lRU
+nwV
+oDz
+sVG
 fnC
 fnC
 fnC
@@ -119140,13 +119163,13 @@ uXv
 ujm
 ujm
 onF
-vZY
-gFf
-irB
-mDu
-eDg
-gFf
-vZY
+sVG
+nwV
+lRU
+uCS
+fOk
+nwV
+sVG
 vVd
 vVd
 fnC
@@ -119592,13 +119615,13 @@ uXv
 ujm
 ujm
 onF
-vZY
-baC
-gFf
-eDg
-wNn
-lAA
-vZY
+sVG
+eKt
+nwV
+fOk
+oVu
+upV
+sVG
 fnC
 fnC
 fnC
@@ -120044,13 +120067,13 @@ uXv
 ujm
 ujm
 onF
-vZY
-odt
-iDX
-vZY
-oDE
-jFO
-vZY
+sVG
+nWC
+mfp
+sVG
+fRi
+tZX
+sVG
 onF
 onF
 onF
@@ -120496,13 +120519,13 @@ uXv
 ujm
 ujm
 onF
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
 onF
 onF
 onF
@@ -233045,13 +233068,13 @@ ogs
 qmf
 onF
 onF
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
 onF
 onF
 onF
@@ -233497,13 +233520,13 @@ ogs
 qmf
 onF
 onF
-vZY
-gPf
-dhA
-nUx
-fAh
-wVY
-vZY
+sVG
+bvY
+rkY
+iGu
+lBo
+voQ
+sVG
 onF
 onF
 onF
@@ -233949,13 +233972,13 @@ ogs
 qmf
 onF
 onF
-vZY
+sVG
 xlZ
-cwy
-bBf
-cwy
-qHT
-vZY
+sCn
+veG
+sCn
+xOs
+sVG
 onF
 onF
 onF
@@ -234401,13 +234424,13 @@ ogs
 qmf
 onF
 onF
-vZY
-vZY
-cwy
-cwy
-pJh
-fix
-vZY
+sVG
+sVG
+sCn
+sCn
+eTI
+bfS
+sVG
 onF
 onF
 onF
@@ -234853,13 +234876,13 @@ ogs
 qmf
 onF
 onF
-vZY
-vZY
-mGK
-cwy
-cwy
-oHb
-vZY
+sVG
+sVG
+ebm
+sCn
+sCn
+goI
+sVG
 onF
 onF
 onF
@@ -235305,13 +235328,13 @@ ogs
 qmf
 onF
 onF
-vZY
-vZY
-cwy
-vRr
-lRB
-auT
-vZY
+sVG
+sVG
+sCn
+wZA
+tVN
+vHN
+sVG
 onF
 onF
 onF
@@ -235757,13 +235780,13 @@ ogs
 qmf
 onF
 onF
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
 onF
 onF
 onF
@@ -241192,7 +241215,7 @@ onF
 onF
 onF
 onF
-qAr
+fvH
 onF
 onF
 onF
@@ -346953,14 +346976,14 @@ tsB
 tsB
 tsB
 tsB
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-vZY
-vZY
+rjm
+rjm
+rjm
+rjm
+rjm
+rjm
+sVG
+sVG
 tsB
 tsB
 tsB
@@ -347405,14 +347428,14 @@ tsB
 tsB
 tsB
 tsB
-pIz
-lrX
-lYg
-lYg
-lYg
-aSY
-rxf
-vZY
+rjm
+dkw
+qoE
+qoE
+qoE
+ylK
+vbj
+sVG
 tsB
 tsB
 tsB
@@ -347857,21 +347880,21 @@ tsB
 tsB
 tsB
 tsB
-pIz
-lYg
-lYg
-nPj
-lYg
-gPf
-lYg
-vZY
-pIz
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
+rjm
+qoE
+qoE
+hkI
+qoE
+bvY
+qoE
+sVG
+rjm
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
 tsB
 tsB
 tsB
@@ -348309,21 +348332,21 @@ tsB
 tsB
 tsB
 tsB
-pIz
-wvO
-lYg
-gPf
-xlS
-gPf
-uNe
-vZY
-vZY
-vZY
-khZ
-mUr
-bzl
-mPo
-vZY
+rjm
+kQp
+qoE
+bvY
+fRf
+bvY
+bYB
+sVG
+sVG
+sVG
+jYO
+pFp
+nnU
+rri
+sVG
 tsB
 tsB
 tsB
@@ -348758,25 +348781,25 @@ ogs
 qmf
 tsB
 tsB
-vZY
-vZY
-vZY
-vZY
-gPf
-gPf
-gPf
-xJR
-lYg
-gPf
-hmS
-vZY
-vZY
-bzl
-bzl
-pSI
-bzl
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+bvY
+bvY
+bvY
+rzW
+qoE
+bvY
+ndN
+sVG
+sVG
+nnU
+nnU
+kFd
+nnU
+sVG
+sVG
 tsB
 tsB
 tsB
@@ -349209,26 +349232,26 @@ ogs
 (134,1,3) = {"
 qmf
 tsB
-vZY
-vZY
-eLG
-vZY
-vZY
-oBJ
-gPf
-gPf
-lYg
-gPf
-gPf
-gPf
-ntT
-bzl
-pUy
+sVG
+sVG
+snX
+sVG
+sVG
+noj
+bvY
+bvY
+qoE
+bvY
+bvY
+bvY
+sDF
+nnU
+nRS
 sMF
 wRj
-bzl
-cJl
-vZY
+nnU
+hBM
+sVG
 tsB
 tsB
 tsB
@@ -349661,26 +349684,26 @@ ogs
 (135,1,3) = {"
 qmf
 tsB
-vZY
-dmh
+sVG
+dvS
 xlZ
-eUn
-vZY
-vZY
-ntT
-vZY
-vZY
-lYg
-vZY
-vZY
-vZY
-tLg
-loH
+xyl
+sVG
+sVG
+sDF
+sVG
+sVG
+qoE
+sVG
+sVG
+sVG
+pnI
+bWj
 ggA
 vUY
-lip
-qZe
-vZY
+ekP
+gTx
+sVG
 tsB
 tsB
 tsB
@@ -350113,28 +350136,28 @@ ogs
 (136,1,3) = {"
 qmf
 tsB
-vZY
-gPf
-gPf
-gPf
-vZY
-gPf
-gPf
-vZY
-mLS
-lYg
-vZY
-vZY
-hjk
-bzl
-bzl
+sVG
+bvY
+bvY
+bvY
+sVG
+bvY
+bvY
+sVG
+dAM
+qoE
+sVG
+sVG
+pNY
+nnU
+nnU
 cVK
 vDS
-wQI
-bzl
-vZY
-vZY
-vZY
+lda
+nnU
+sVG
+sVG
+sVG
 tsB
 tsB
 tsB
@@ -350565,27 +350588,27 @@ ogs
 (137,1,3) = {"
 qmf
 tsB
-vZY
-tTc
-gPf
-gPf
-vWv
-gPf
-gPf
-vZY
-fqu
-lYg
-vZY
+sVG
+hFO
+bvY
+bvY
+oKD
+bvY
+bvY
+sVG
+ouC
+qoE
+sVG
 gfT
-bzl
-bzl
-bzl
-bzl
-bzl
-bzl
-bzl
-bzl
-sDo
+nnU
+nnU
+nnU
+nnU
+nnU
+nnU
+nnU
+nnU
+vWe
 fnC
 fnC
 tsB
@@ -351017,27 +351040,27 @@ ogs
 (138,1,3) = {"
 qmf
 tsB
-vZY
-dZM
-hhd
-gPf
-vZY
-gPf
-pQV
-vZY
-mHd
-aSY
-vZY
+sVG
+vHl
+gte
+bvY
+sVG
+bvY
+qYJ
+sVG
+uhi
+ylK
+sVG
 gfT
-bzl
-bzl
-sLv
-bzl
-bzl
-aiL
-bzl
-rRI
-vZY
+nnU
+nnU
+jCG
+nnU
+nnU
+sAi
+nnU
+vbS
+sVG
 fnC
 fnC
 fnC
@@ -351469,27 +351492,27 @@ ogs
 (139,1,3) = {"
 qmf
 tsB
-vZY
-vZY
-vZY
-vZY
-vZY
-cvb
-gPf
-vZY
-gia
-lYg
-vZY
-vZY
-cxa
-bzl
-vZY
-qWj
-qWj
-vZY
-gPf
-bzl
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+pBW
+bvY
+sVG
+mwM
+qoE
+sVG
+sVG
+ccr
+nnU
+sVG
+eYZ
+eYZ
+sVG
+bvY
+nnU
+sVG
 oPv
 tsB
 tsB
@@ -351921,27 +351944,27 @@ ogs
 (140,1,3) = {"
 qmf
 tsB
-vZY
-vZY
-vZY
-vZY
-vZY
-fnG
-gPf
-vZY
-vZY
-vZY
-vZY
-krm
-gPf
-bzl
-vZY
-vZY
-vZY
-vZY
-ntT
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+aCM
+bvY
+sVG
+sVG
+sVG
+sVG
+apz
+bvY
+nnU
+sVG
+sVG
+sVG
+sVG
+sDF
+sVG
+sVG
 tsB
 tsB
 tsB
@@ -352373,27 +352396,27 @@ ogs
 (141,1,3) = {"
 qmf
 tsB
-vZY
-utc
-wvA
-utc
-bfo
-gPf
-gPf
-gPf
-gPf
-gPf
-gPf
-gPf
-gPf
-bzl
-vZY
-aUl
-sHz
-gPf
-gPf
-ddf
-vZY
+sVG
+kTq
+wjI
+kTq
+eUs
+bvY
+bvY
+bvY
+bvY
+bvY
+bvY
+bvY
+bvY
+nnU
+sVG
+kDl
+bPD
+bvY
+bvY
+fhV
+sVG
 qPv
 qPv
 qPv
@@ -352825,31 +352848,31 @@ ogs
 (142,1,3) = {"
 qmf
 tsB
-vZY
-iwp
-gPf
-gPf
-gPf
-gPf
-gPf
-egW
-gPf
-bmj
-gPf
-egW
-gPf
-bzl
-vZY
-hfU
-gPf
-wsC
-gPf
-bzl
-vZY
-vZY
-vZY
-vZY
-vZY
+sVG
+xqz
+bvY
+bvY
+bvY
+bvY
+bvY
+lmn
+bvY
+gjF
+bvY
+lmn
+bvY
+nnU
+sVG
+qpN
+bvY
+qRd
+bvY
+nnU
+sVG
+sVG
+sVG
+sVG
+sVG
 qPv
 qPv
 qPv
@@ -353277,30 +353300,30 @@ ogs
 (143,1,3) = {"
 qmf
 tsB
-vZY
-oSK
-gPf
-sxD
-xuW
-gPf
-gPf
-vZY
-eBC
-vZY
-eBC
-vZY
+sVG
+dqw
+bvY
+ulV
+pWk
+bvY
+bvY
+sVG
+xLf
+sVG
+xLf
+sVG
 xlZ
 jCq
-vZY
-hNN
-gPf
-sKy
-rSd
-bzl
+sVG
+niH
+bvY
+tPQ
+fIs
+nnU
 lbV
-jiW
+vHQ
 lbV
-lqL
+aGH
 lbV
 qPv
 qPv
@@ -353729,30 +353752,30 @@ ogs
 (144,1,3) = {"
 qmf
 tsB
-vZY
-iqj
-rlY
-gPf
-fYs
-gPf
-gPf
-vZY
-pIz
-pIz
-pIz
-vZY
-vZY
-vZY
-vZY
-jLb
-gPf
-gfg
-gPf
-bzl
+sVG
+cgN
+xnW
+bvY
+xIW
+bvY
+bvY
+sVG
+rjm
+rjm
+rjm
+sVG
+sVG
+sVG
+sVG
+nNV
+bvY
+aDE
+bvY
+nnU
 lbV
-mKu
-nkb
-hyg
+mFj
+cxf
+hmm
 qPv
 qPv
 qPv
@@ -354181,30 +354204,30 @@ ogs
 (145,1,3) = {"
 qmf
 tsB
-vZY
-buk
-utc
-utc
-wUP
-gPf
-pQV
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-kFr
-vZY
-vZY
-vZY
-vZY
+sVG
+fms
+kTq
+kTq
+xKf
+bvY
+qYJ
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+gmv
+sVG
+sVG
+sVG
+sVG
 qPv
 qPv
 dCq
@@ -354633,30 +354656,30 @@ ogs
 (146,1,3) = {"
 qmf
 tsB
-vZY
-vZY
-vZY
-vZY
-vZY
-cxa
-gPf
-vZY
-bcK
-sHz
-mss
-iLc
-cOk
-gPf
-gPf
-gPf
-gPf
-gPf
-gPf
-bzl
-vZY
-gTQ
-wAW
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+ccr
+bvY
+sVG
+lVn
+bPD
+tBP
+jfS
+qVM
+bvY
+bvY
+bvY
+bvY
+bvY
+bvY
+nnU
+sVG
+uWJ
+dDS
+sVG
 qPv
 dCq
 dCq
@@ -355089,26 +355112,26 @@ tsB
 tsB
 tsB
 tsB
-vZY
-gPf
-gPf
-ntT
-gPf
-gPf
-gPf
-gPf
-gPf
-gPf
-wUP
-gPf
-wUP
-gPf
-gPf
-bzl
-kFr
-sgq
-bzl
-vZY
+sVG
+bvY
+bvY
+sDF
+bvY
+bvY
+bvY
+bvY
+bvY
+bvY
+xKf
+bvY
+xKf
+bvY
+bvY
+nnU
+gmv
+jmP
+nnU
+sVG
 qPv
 dCq
 dCq
@@ -355541,26 +355564,26 @@ tsB
 tsB
 tsB
 tsB
-vZY
-vZY
-vZY
-vZY
-gPf
-gPf
-xcw
-gPf
-gPf
-vZY
-vZY
-fJw
-vZY
-vZY
-poC
-rJv
-vZY
-hoH
-hsc
 sVG
+sVG
+sVG
+sVG
+bvY
+bvY
+huO
+bvY
+bvY
+sVG
+sVG
+vnU
+sVG
+sVG
+mUD
+hNQ
+sVG
+blM
+cYJ
+vZY
 dCq
 dCq
 dCq
@@ -355996,23 +356019,23 @@ tsB
 tsB
 tsB
 tsB
-vZY
-osg
-tOA
-nUe
-tOA
-gms
-vZY
+sVG
+kYG
+orX
+vuG
+orX
+alR
+sVG
 tsB
 fnC
 tsB
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
 dCq
 dCq
 qPv
@@ -356448,13 +356471,13 @@ tsB
 tsB
 tsB
 tsB
-vZY
-vZY
-vZY
-vZY
-pIz
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+rjm
+sVG
+sVG
 tsB
 fnC
 tsB
@@ -462665,9 +462688,9 @@ gBM
 nsX
 nsX
 nsX
-lYg
-lYg
-lYg
+qoE
+qoE
+qoE
 nsX
 gTH
 gTH
@@ -462675,9 +462698,9 @@ gTH
 gTH
 nsX
 nsX
-rlM
-fWH
-gLz
+slv
+sfi
+qeo
 nsX
 nsX
 gTH
@@ -463116,21 +463139,21 @@ gBM
 gBM
 nsX
 nsX
-lYg
-lYg
+qoE
+qoE
 nsX
-lYg
+qoE
 nsX
 nsX
 gTH
 gTH
 nsX
 nsX
-oFV
-cUW
+pVl
+roY
 iFL
-sNB
-sNB
+jsF
+jsF
 nsX
 nsX
 nsX
@@ -463567,25 +463590,25 @@ ogs
 gBM
 gBM
 nsX
-lYg
-lYg
+qoE
+qoE
 nsX
 nsX
-fYe
-fWH
+cro
+sfi
 nsX
 nsX
 nsX
 nsX
 nsX
-lYg
-hQp
-cwy
-cwy
-cwy
-cwy
-nfl
-bkx
+qoE
+hhB
+sCn
+sCn
+sCn
+sCn
+wks
+ylu
 nsX
 gTH
 gTH
@@ -464019,26 +464042,26 @@ ogs
 gBM
 gBM
 nsX
-lYg
+qoE
 nsX
 nsX
-fWH
-vZY
-qlS
+sfi
+sVG
+uLr
 nsX
 nsX
-lYg
-lYg
-lYg
-lYg
-hQp
-cwy
-hKx
-cwy
-cwy
-nfl
-hWC
-vZY
+qoE
+qoE
+qoE
+qoE
+hhB
+sCn
+xOB
+sCn
+sCn
+wks
+naD
+sVG
 gTH
 gTH
 gTH
@@ -464471,26 +464494,26 @@ ogs
 gBM
 gBM
 nsX
-lYg
-rUT
-vZY
-qas
-fWH
-fuo
-fWH
-lYg
-lYg
-oFV
+qoE
+oLj
+sVG
+teD
+sfi
+goQ
+sfi
+qoE
+qoE
+pVl
 nsX
-lYg
-hQp
-cwy
-cwy
-cwy
-cwy
-nfl
-iwR
-vZY
+qoE
+hhB
+sCn
+sCn
+sCn
+sCn
+wks
+dUL
+sVG
 gTH
 gTH
 gTH
@@ -464923,26 +464946,26 @@ ogs
 gBM
 gBM
 nsX
-lYg
+qoE
 nsX
 nsX
-fWH
-fWH
-hBp
-fWH
-lYg
+sfi
+sfi
+bJF
+sfi
+qoE
 nsX
 nsX
 nsX
-fYe
-hQp
-cwy
-cwy
-cwy
-cwy
-nfl
-fWH
-vZY
+cro
+hhB
+sCn
+sCn
+sCn
+sCn
+wks
+uSz
+sVG
 gTH
 gTH
 gTH
@@ -465374,33 +465397,33 @@ ogs
 (136,1,4) = {"
 gBM
 gBM
-aHe
-lYg
+gjs
+qoE
 nsX
-vZY
-fWH
-vZY
-fWH
-fWH
-vZY
-vZY
-vZY
-vZY
-vZY
-hQp
-cwy
-cwy
-cwy
-cwy
-nfl
-fWH
-vZY
-vZY
+sVG
+sfi
+sVG
+sfi
+sfi
+sVG
+sVG
+sVG
+sVG
+sVG
+hhB
+sCn
+sCn
+sCn
+sCn
+wks
+sfi
+sVG
+sVG
 nsX
-vZY
-vZY
+sVG
+sVG
 dCq
-xPa
+joc
 dCq
 dCq
 dCq
@@ -465827,30 +465850,30 @@ ogs
 gBM
 gBM
 nsX
-hsZ
+ltM
 nsX
-vZY
-eaI
-mma
-fWH
-fWH
-fWH
-fWH
+sVG
+rzm
+laN
+sfi
+sfi
+sfi
+sfi
 gfT
-cwy
-vZY
-sJe
-cwy
-oRi
-cwy
-cwy
-nfl
-fWH
-fWH
-jFW
-fWH
-fWH
-rRA
+sCn
+sVG
+eyP
+sCn
+bjS
+sCn
+sCn
+wks
+sfi
+sfi
+lCs
+sfi
+sfi
+tFr
 dCq
 gTH
 dCq
@@ -466281,28 +466304,28 @@ gBM
 nsX
 nsX
 nsX
-vZY
-jFW
-fWH
-fWH
-fWH
-fWH
-fWH
+sVG
+lCs
+sfi
+sfi
+sfi
+sfi
+sfi
 gfT
-cwy
-vZY
-hgr
-cwy
-cwy
-cwy
-cwy
-nfl
-fWH
-fWH
-fWH
-fWH
-fWH
-vZY
+sCn
+sVG
+kVp
+sCn
+sCn
+sCn
+sCn
+wks
+sfi
+sfi
+sfi
+sfi
+sfi
+sVG
 gTH
 gTH
 gTH
@@ -466733,28 +466756,28 @@ gBM
 nsX
 nsX
 nsX
-vZY
-eaI
-vZY
-qlS
-fWH
-vZY
-vZY
-vZY
-vZY
-vZY
-gvf
-qMM
-qMM
-qMM
-qMM
-bhv
-fWH
-vZY
+sVG
+rzm
+sVG
+uLr
+sfi
+sVG
+sVG
+sVG
+sVG
+sVG
+bDJ
+wYa
+wYa
+wYa
+wYa
+ouk
+sfi
+sVG
 nsX
 nsX
-vZY
-vZY
+sVG
+sVG
 gTH
 gTH
 gTH
@@ -467185,24 +467208,24 @@ gBM
 nsX
 nsX
 nsX
-vZY
-fWH
-fWH
-fWH
-fWH
-vZY
+sVG
+sfi
+sfi
+sfi
+sfi
+sVG
 nsX
 nsX
-fWH
-fWH
-fWH
-fWH
-fWH
-fWH
-fWH
-fWH
-hWC
-vZY
+eDh
+sfi
+sfi
+sfi
+sfi
+sfi
+sfi
+sfi
+naD
+sVG
 gTH
 gTH
 gTH
@@ -467634,27 +467657,27 @@ ogs
 (141,1,4) = {"
 gBM
 gBM
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
 nsX
 nsX
 nsX
-fWH
-fYe
+sfi
+cro
 nsX
 nsX
 nsX
-vZY
-vZY
-ody
-vZY
+sVG
+sVG
+fXn
+sVG
 gTH
 gTH
 gTH
@@ -468086,26 +468109,26 @@ ogs
 (142,1,4) = {"
 gBM
 gBM
-vZY
-tSD
-mqa
+sVG
+prj
+qGD
 wgH
-mqa
+qGD
 uEw
 aJD
-qCJ
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
+mXZ
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
 nsX
 nsX
 nsX
 nsX
-mCL
+fuJ
 nsX
 gTH
 gTH
@@ -468538,27 +468561,27 @@ ogs
 (143,1,4) = {"
 gBM
 gBM
-vZY
+sVG
 bUj
-xas
+nPZ
 rva
-mqa
-fQf
-aKk
-mqa
+qGD
+bWg
+rga
+qGD
 rva
-mqa
+qGD
 bUj
-vZY
-cwy
-cwy
-vZY
+sVG
+sCn
+sCn
+sVG
 nsX
-ioP
+cLb
 nsX
 nsX
-oFV
-lYg
+pVl
+qoE
 gTH
 gTH
 gTH
@@ -468990,27 +469013,27 @@ ogs
 (144,1,4) = {"
 gBM
 gBM
-vZY
-vZY
-vZY
-vZY
+sVG
+sVG
+sVG
+sVG
 lKP
-vhA
-mqa
-mqa
+bHI
+qGD
+qGD
 wgH
-xas
-sYF
-vZY
+nPZ
+tSD
+sVG
+qgT
 mec
-aeh
-vZY
-lYg
-lYg
+sVG
+qoE
+qoE
 nsX
 nsX
 nsX
-lYg
+qoE
 gTH
 gTH
 gTH
@@ -469442,27 +469465,27 @@ ogs
 (145,1,4) = {"
 gBM
 gBM
-vZY
+sVG
 vGh
-mqa
-vZY
-vZY
-vZY
+qGD
+sVG
+sVG
+sVG
 duu
-vZY
-vZY
-vZY
-vZY
-vZY
-mqa
-mqa
-vZY
-ioP
-lYg
-lYg
+sVG
+sVG
+sVG
+sVG
+sVG
+qGD
+qGD
+sVG
+cLb
+qoE
+qoE
 nsX
-lYg
-lYg
+qoE
+qoE
 gTH
 gTH
 gTH
@@ -469894,26 +469917,26 @@ ogs
 (146,1,4) = {"
 gBM
 gBM
-vZY
+sVG
 mCg
-mqa
+qGD
 ngu
 bcM
-mqa
-mqa
-lXQ
-mqa
-mqa
-mqa
-mqa
-mqa
-qte
-vZY
+qGD
+qGD
+vab
+qGD
+qGD
+qGD
+qGD
+qGD
+tLm
+sVG
 nsX
-lYg
-lYg
-lYg
-lYg
+qoE
+qoE
+qoE
+qoE
 nsX
 gTH
 gTH
@@ -470346,26 +470369,26 @@ ogs
 (147,1,4) = {"
 gBM
 gBM
-vZY
-vZY
-vZY
-vZY
-vZY
-mqa
-mqa
-rTt
-mqa
-mqa
-rTt
-mqa
-mqa
-mqa
-vZY
+sVG
+sVG
+sVG
+sVG
+sVG
+qGD
+qGD
+xoz
+qGD
+qGD
+xoz
+qGD
+qGD
+qGD
+sVG
 nsX
-lYg
+qoE
 nsX
 nsX
-lYg
+qoE
 nsX
 gTH
 gTH
@@ -470798,26 +470821,26 @@ ogs
 (148,1,4) = {"
 gBM
 gBM
-vZY
-ezV
-mqa
-mqa
+sVG
+nQT
+qGD
+qGD
 pGG
-mqa
-vZY
-vZY
-vZY
-vZY
-vZY
-vZY
-mqa
-mqa
-vZY
+qGD
+sVG
+sVG
+sVG
+sVG
+sVG
+sVG
+qGD
+qGD
+sVG
 nsX
-lYg
+qoE
 nsX
-oFV
-lYg
+pVl
+qoE
 nsX
 gTH
 gTH
@@ -471250,27 +471273,27 @@ ogs
 (149,1,4) = {"
 gBM
 gBM
-vZY
+sVG
 dgd
-mqa
-nBH
-vZY
-vZY
-vZY
+qGD
+nVv
+sVG
+sVG
+sVG
 eNd
-miT
-qKL
+qCM
+fBd
 qUh
-vZY
-mqa
-qte
-vZY
+sVG
+qGD
+tLm
+sVG
 nsX
-lYg
-lYg
-rUT
-lYg
-oFV
+qoE
+qoE
+oLj
+qoE
+pVl
 gTH
 gTH
 fwS
@@ -471702,28 +471725,28 @@ ogs
 (150,1,4) = {"
 gBM
 gBM
-vZY
-ses
+sVG
+gEI
 iTB
 yaC
-vZY
+sVG
 iJM
-gLN
-iei
+sqF
+bSp
 nzP
-vZY
-miT
-vZY
-oKT
-kFB
-vZY
-vZY
-vZY
-lYg
-lYg
-lYg
-lYg
-vZY
+sVG
+qCM
+sVG
+mhU
+ihR
+sVG
+sVG
+sVG
+qoE
+qoE
+qoE
+qoE
+sVG
 gTH
 vMR
 vMR
@@ -472154,28 +472177,28 @@ cxA
 (151,1,4) = {"
 gBM
 gBM
-vZY
-vZY
-vZY
-vZY
-vZY
-qGD
+sVG
+sVG
+sVG
+sVG
+sVG
 uVt
+lup
+lup
+lup
 uVt
-uVt
-qGD
-iei
+bSp
 oVo
-mqa
-fWH
+qGD
+sfi
 vEG
-lYg
-lYg
-lYg
-lYg
-lYg
-lYg
-vZY
+qoE
+qoE
+qoE
+qoE
+qoE
+qoE
+sVG
 vMR
 vMR
 vMR
@@ -472610,24 +472633,24 @@ gTH
 gTH
 qRS
 rCo
-vZY
+sVG
 hkO
-uVt
+lup
 bib
 ijH
-gLN
-gLN
+sqF
+sqF
 cvH
-fWH
-fWH
-plf
-lYg
-fWH
-lYg
-lYg
+sfi
+sfi
+unI
+qoE
+sfi
+qoE
+qoE
 eQQ
-fWH
-sVG
+sfi
+vZY
 vMR
 vMR
 vMR
@@ -473064,22 +473087,22 @@ dCq
 eGi
 lNG
 pug
+lup
+lup
+lup
 uVt
-uVt
-uVt
-qGD
-iei
+bSp
 cvH
-mqa
+qGD
 pqX
-vZY
-lYg
-lYg
-lYg
-lYg
-fWH
-tav
-vZY
+sVG
+qoE
+qoE
+qoE
+qoE
+sfi
+ioM
+sVG
 vMR
 vMR
 vMR
@@ -473514,24 +473537,24 @@ gTH
 dCq
 dCq
 uFa
-vZY
-vZY
+sVG
+sVG
 aAn
-gLN
-iei
-vZY
-miT
-vZY
-oKT
-hWC
-vZY
+sqF
+bSp
+sVG
+qCM
+sVG
+mhU
+naD
+sVG
 nsX
-lYg
-oFV
-lYg
-jff
-vZY
-vZY
+qoE
+pVl
+qoE
+xNv
+sVG
+sVG
 vMR
 vMR
 vMR
@@ -473967,22 +473990,22 @@ vMR
 vMR
 pTA
 rCo
-vZY
-vZY
+sVG
+sVG
 jVb
-gLN
+sqF
 qqz
 wCy
-vZY
-fWH
-fWH
-vZY
+sVG
+sfi
+sfi
+sVG
 nsX
 nsX
 nsX
-lYg
-lYg
-vZY
+qoE
+qoE
+sVG
 vMR
 vMR
 vMR
@@ -474420,13 +474443,13 @@ vMR
 vMR
 pTA
 rCo
-vZY
-vZY
-rjm
-vZY
-vZY
-vZY
-mqa
+sVG
+sVG
+lNG
+sVG
+sVG
+sVG
+qGD
 pqX
 gTH
 gTH
@@ -474877,8 +474900,8 @@ qRS
 iVB
 qRS
 nsX
-vZY
-cvH
+sVG
+hep
 gTH
 gTH
 gTH
@@ -475326,7 +475349,7 @@ vMR
 vMR
 vMR
 dCq
-wJW
+igp
 dCq
 gTH
 fwS
@@ -476233,7 +476256,7 @@ vMR
 dCq
 dCq
 mUC
-wJW
+igp
 gTH
 gTH
 gTH

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -200,6 +200,15 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"aeh" = (
+/obj/structure/stairs/stone{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder/directional/south,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aen" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -433,6 +442,11 @@
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
+"aiL" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aiP" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -1028,6 +1042,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"auT" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "avc" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -1256,8 +1278,9 @@
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 8
 	},
+/obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aAE" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors)
@@ -1494,6 +1517,10 @@
 	},
 /turf/open/lava/acid,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"aHe" = (
+/obj/item/storage/belt/rogue/pouch/coins/rich,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aHj" = (
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
@@ -1648,10 +1675,15 @@
 	icon_state = "largetable";
 	dir = 6
 	},
+/obj/item/rogueweapon/surgery/scalpel,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -10;
+	pixel_y = 6
+	},
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aJI" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -1667,6 +1699,12 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors)
+"aKk" = (
+/mob/living/carbon/human/species/skeleton/npc/no_equipment,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aKn" = (
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/concrete,
@@ -2111,6 +2149,12 @@
 	dir = 10
 	},
 /area/rogue/outdoors/town/roofs)
+"aSY" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mole{
+	faction = list("wolfs","undead")
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aTj" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/clothing/under/roguetown/tights/black,
@@ -2175,6 +2219,13 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
+"aUl" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/food,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "aUm" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -2468,6 +2519,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
+"baC" = (
+/turf/open/floor/rogue/concrete{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "baE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -2573,12 +2629,18 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
+"bcK" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bcM" = (
-/mob/living/simple_animal/hostile/rogue/skeleton,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bcS" = (
 /obj/structure/winch{
 	dir = 4;
@@ -2675,6 +2737,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
+"bfo" = (
+/obj/structure/fluff/statue/knight/interior,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bfr" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/cobble,
@@ -2752,6 +2820,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
+"bhv" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bhB" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/chair/wood/rogue/chair3,
@@ -2799,7 +2873,7 @@
 "bib" = (
 /obj/structure/flora/roguetree/underworld,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bik" = (
 /obj/structure/stairs{
 	dir = 1
@@ -2889,6 +2963,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
+"bkx" = (
+/obj/structure/fermenting_barrel/sourwine,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bkK" = (
 /obj/effect/decal/remains/saiga,
 /turf/open/floor/rogue/dirt/road,
@@ -2950,6 +3028,12 @@
 	dir = 4
 	},
 /area/rogue/outdoors/woods)
+"bmj" = (
+/obj/machinery/light/rogue/torchholder/directional/east,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bmv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3339,6 +3423,14 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
+"buk" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bum" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -3508,6 +3600,9 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"bzl" = (
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bzq" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -3605,6 +3700,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"bBf" = (
+/obj/structure/fluff/walldeco/chains,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bBi" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -4632,7 +4731,7 @@
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bUq" = (
 /obj/structure/bars,
 /obj/structure/bars/passage{
@@ -5740,6 +5839,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
+"cvb" = (
+/obj/structure/fluff/statue,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cvG" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -5748,7 +5853,7 @@
 /area/rogue/under/underdark)
 "cvH" = (
 /turf/open/floor/rogue/greenstone,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cvZ" = (
 /obj/structure/closet/crate/chest{
 	base_icon_state = "woodchestalt";
@@ -5761,6 +5866,9 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"cwy" = (
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cwF" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -5797,6 +5905,14 @@
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
+"cxa" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cxi" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -6330,6 +6446,12 @@
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"cJl" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cJt" = (
 /obj/structure/rack/rogue,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -6562,6 +6684,14 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/vulnafir)
+"cOk" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cOm" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 8
@@ -6879,6 +7009,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
+"cUW" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cVh" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -6933,11 +7069,11 @@
 /area/rogue/under/cave/dungeon/old_ruin)
 "cVK" = (
 /obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+	icon_state = "map6"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/cave)
+/obj/item/storage/belt/rogue/pouch/coins/poor,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cVQ" = (
 /obj/structure/stairs{
 	dir = 1
@@ -7275,6 +7411,10 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/winding_halls)
+"ddf" = (
+/obj/structure/fermenting_barrel/murkwine,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ddr" = (
 /obj/structure/chair/bench/church/mid,
 /turf/open/floor/rogue/concrete,
@@ -7387,14 +7527,12 @@
 /area/rogue/outdoors/bog)
 "dgd" = (
 /obj/structure/table/wood,
-/obj/structure/fluff/walldeco/med5{
-	pixel_x = 4;
-	pixel_y = 32
-	},
+/obj/structure/fireaxecabinet/south,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dge" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -7456,6 +7594,15 @@
 /obj/structure/fluff/walldeco/rpainting,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cave/dungeon/abandoned_manor)
+"dhA" = (
+/obj/item/restraints/legcuffs/beartrap,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dhP" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/church,
@@ -7593,6 +7740,15 @@
 "dlW" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors)
+"dmh" = (
+/obj/effect/decal/cleanable/dirt/cobweb,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dmp" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/cobble,
@@ -8004,14 +8160,13 @@
 	},
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "duu" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	dir = 8
+/obj/structure/mineral_door/wood{
+	locked = 1
 	},
 /turf/open/floor/rogue/greenstone{
 	dir = 1
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "duy" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/tile,
@@ -9436,6 +9591,13 @@
 /obj/item/reagent_containers/glass/cup/golden,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/dungeon/licharena)
+"dZM" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dZS" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -9487,6 +9649,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/dwarfin)
+"eaI" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eaQ" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9699,6 +9867,14 @@
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/winding_halls)
+"egW" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ehc" = (
 /obj/structure/spider/stickyweb{
 	icon_state = "stickyweb2"
@@ -10731,6 +10907,20 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
+"ezV" = (
+/obj/structure/winch{
+	gid = "bastilletop";
+	redstone_id = "bastilletop";
+	name = "Tsoridys' Mercy"
+	},
+/obj/structure/fluff/walldeco/med5{
+	pixel_x = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ezW" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -10831,6 +11021,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains)
+"eBC" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eBE" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/rack/rogue,
@@ -10916,6 +11112,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"eDg" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eDp" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood,
@@ -11081,7 +11283,7 @@
 "eGi" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eGj" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11306,6 +11508,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains)
+"eLG" = (
+/obj/machinery/light/rogue/torchholder/directional/west,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eLL" = (
 /obj/item/natural/stone{
 	icon_state = "stone5"
@@ -11355,8 +11561,15 @@
 /area/rogue/outdoors/woods)
 "eNd" = (
 /obj/structure/stone_tile/surrounding_tile,
+/obj/structure/closet/crate/chest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/obj/item/clothing/ring/rubys,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eNp" = (
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
@@ -11538,7 +11751,7 @@
 "eQQ" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/blocks/green,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eQT" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -11742,6 +11955,15 @@
 /obj/structure/roguemachine/bounty,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"eUn" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eUq" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grassyel,
@@ -12441,6 +12663,15 @@
 "fii" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/rtfield)
+"fix" = (
+/obj/machinery/light/rogue/torchholder/directional/south,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fiK" = (
 /obj/structure/stairs{
 	dir = 8
@@ -12680,6 +12911,15 @@
 "fnC" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
+"fnG" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fnJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/bog)
@@ -12792,6 +13032,15 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
+"fqu" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fqA" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -12960,6 +13209,13 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"fuo" = (
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fus" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/wood,
@@ -13244,6 +13500,15 @@
 	dir = 8
 	},
 /area/rogue/under/town/sewer)
+"fAh" = (
+/mob/living/simple_animal/hostile/rogue/dragger,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fAm" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
@@ -13582,6 +13847,12 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"fJw" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fJD" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -13871,6 +14142,14 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"fQf" = (
+/obj/item/chair/rogue/crafted{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fQE" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
@@ -14166,6 +14445,9 @@
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
+"fWH" = (
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fWS" = (
 /obj/item/flint,
 /obj/structure/table/wood{
@@ -14258,6 +14540,10 @@
 "fYc" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"fYe" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fYi" = (
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/dirt/road,
@@ -14288,6 +14574,14 @@
 /obj/item/rogueweapon/stoneaxe/battle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"fYs" = (
+/obj/item/chair/rogue/crafted{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fYD" = (
 /obj/item/ash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14600,6 +14894,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"gfg" = (
+/obj/machinery/light/rogue/oven/west,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gfj" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/roguemachine/scomm/directional/north,
@@ -14622,7 +14922,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/cave)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gfU" = (
 /obj/structure/stairs{
 	dir = 8
@@ -14650,11 +14950,10 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "ggA" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	icon_state = "map5"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/cave)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ggS" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
@@ -14704,6 +15003,14 @@
 /obj/item/toy/cards/deck/tarot,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"gia" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gij" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/garrison)
@@ -14885,6 +15192,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"gms" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gmu" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/cobble,
@@ -15220,6 +15534,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"gvf" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gvg" = (
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -15702,6 +16022,11 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
+"gFf" = (
+/turf/open/floor/rogue/concrete{
+	dir = 1
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gFm" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -16047,6 +16372,11 @@
 /obj/structure/bars/steel,
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"gLz" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gLG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
@@ -16069,6 +16399,9 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains)
+"gLN" = (
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gLW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -16173,6 +16506,11 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/goblinfort)
+"gPf" = (
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gPh" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -16363,6 +16701,12 @@
 "gTH" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/beach/forest)
+"gTQ" = (
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gTY" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
@@ -17027,6 +17371,20 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"hfU" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hfZ" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood,
@@ -17035,6 +17393,14 @@
 /obj/structure/glowshroom,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
+"hgr" = (
+/obj/structure/fluff/railing/border,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hgH" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/roguegrass,
@@ -17056,6 +17422,12 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"hhd" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hhi" = (
 /obj/structure/closet/crate/chest/neu{
 	locked = 1;
@@ -17180,6 +17552,17 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"hjk" = (
+/obj/structure/fluff/statue/small{
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/obj/structure/table/wood,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hjm" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/carpet/red,
@@ -17235,8 +17618,14 @@
 /obj/structure/stone_tile/slab/cracked{
 	dir = 9
 	},
+/obj/structure/closet/crate/chest,
+/obj/item/roguegem/random,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hkR" = (
 /obj/structure/well/fountain{
 	pixel_x = -16
@@ -17328,6 +17717,14 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"hmS" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hmU" = (
 /obj/structure/chair/bench/couch/r,
 /turf/open/floor/rogue/hexstone,
@@ -17412,6 +17809,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"hoH" = (
+/obj/machinery/light/rogue/torchholder/directional/east,
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hoS" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
@@ -17553,6 +17958,10 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"hsc" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hsg" = (
 /obj/structure/roguemachine/mail/directional/south{
 	mailtag = "Dwarven Quarter"
@@ -17610,6 +18019,10 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
+"hsZ" = (
+/mob/living/simple_animal/hostile/rogue/dragger,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "htl" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -17852,6 +18265,12 @@
 "hxX" = (
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/dungeon/goblinfort)
+"hyg" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hyh" = (
 /obj/structure/stairs{
 	dir = 8
@@ -18040,6 +18459,10 @@
 /obj/item/storage/belt/rogue/pouch/coins/rich,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/dungeon/licharena)
+"hBp" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hBy" = (
 /obj/structure/chair/bench/ultimacouch,
 /obj/structure/fluff/walldeco/maidensigil/r,
@@ -18435,6 +18858,11 @@
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"hKx" = (
+/obj/machinery/light/rogue/chand,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hKF" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/ruinedwood{
@@ -18591,6 +19019,20 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
+"hNN" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/glass/bottle{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hNV" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/physician)
@@ -18670,6 +19112,10 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
+"hQp" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hQq" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -18989,6 +19435,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"hWC" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "hWO" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -19403,6 +19855,10 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
+"iei" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ien" = (
 /obj/structure/bars/passage/shutter,
 /turf/open/floor/rogue/dirt/road,
@@ -19644,8 +20100,9 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "ijH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear,
+/obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ijJ" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
 	dir = 1
@@ -19898,6 +20355,10 @@
 /obj/structure/table/vtable,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/dungeon/winding_halls)
+"ioP" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/wolf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ipd" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
@@ -19948,6 +20409,15 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"iqj" = (
+/obj/item/reagent_containers/glass/mortar,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iqx" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/naturalstone,
@@ -20038,6 +20508,12 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
+"irB" = (
+/obj/item/roguegem/random,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "irI" = (
 /obj/structure/bars/pipe,
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -20226,6 +20702,15 @@
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/indoors/cave)
+"iwp" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iwF" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
@@ -20247,6 +20732,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"iwR" = (
+/obj/machinery/light/rogue/torchholder/directional/south,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iwT" = (
 /obj/machinery/light/roguestreet{
 	dir = 1
@@ -20647,6 +21136,12 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/shop)
+"iDX" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iDZ" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town/tavern)
@@ -20728,8 +21223,11 @@
 /area/rogue/indoors/shelter/woods)
 "iFL" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
 /turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iGc" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/under/roguetown/trou/leather,
@@ -20844,8 +21342,13 @@
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 1
 	},
+/obj/structure/winch{
+	gid = "bastilletop";
+	redstone_id = "bastilletop";
+	name = "Tsoridys' Mercy"
+	},
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iJP" = (
 /obj/machinery/light/rogue/firebowl{
 	light_color = "#b30202"
@@ -20935,6 +21438,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"iLc" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iLf" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains7"
@@ -21393,7 +21906,7 @@
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iTJ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -21496,7 +22009,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iVE" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/garrison)
@@ -22006,6 +22519,10 @@
 /obj/structure/closet/crate/drawer/random,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"jff" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jfh" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -22210,6 +22727,12 @@
 /obj/item/paper/scroll,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"jiW" = (
+/obj/machinery/light/rogue/torchholder/directional/west,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jiY" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	icon_state = "iron_corner";
@@ -23012,7 +23535,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/cave)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jCt" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassred,
@@ -23157,6 +23680,14 @@
 "jFA" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
+"jFO" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
+"jFW" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jGl" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -23392,6 +23923,17 @@
 "jKY" = (
 /turf/open/water/sewer,
 /area/rogue/outdoors/mountains/decap)
+"jLb" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jLl" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/structure/fluff/railing/border{
@@ -23856,8 +24398,14 @@
 /obj/structure/stone_tile/slab/cracked{
 	dir = 5
 	},
+/obj/structure/closet/crate/chest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jVf" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/rack/rogue/shelf/biggest,
@@ -24388,6 +24936,10 @@
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
+"khZ" = (
+/obj/structure/fluff/statue/knight/interior,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kil" = (
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
@@ -24725,6 +25277,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"krm" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "krw" = (
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/town/roofs)
@@ -25387,6 +25943,16 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
+"kFr" = (
+/obj/structure/mineral_door/wood/violet,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
+"kFB" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kFC" = (
 /obj/structure/closet/crate/chest/lootbox,
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/east,
@@ -26356,6 +26922,12 @@
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"kZp" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/concrete{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kZu" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -26488,7 +27060,7 @@
 /turf/open/floor/rogue/blocks{
 	dir = 4
 	},
-/area/rogue/indoors/cave)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lbY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -26799,6 +27371,10 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
+"lip" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "liq" = (
 /obj/item/chair/rogue{
 	dir = 1
@@ -27108,6 +27684,10 @@
 	dir = 4
 	},
 /area/rogue/under/town/basement)
+"loH" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "loK" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/huntingknife/idagger,
@@ -27217,6 +27797,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
+"lqL" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lqM" = (
 /obj/structure/closet/crate/drawer/random,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -27257,6 +27843,10 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"lrX" = (
+/obj/structure/fermenting_barrel/beer,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lrZ" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/cobble/mossy,
@@ -27637,6 +28227,11 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"lAA" = (
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lAE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -28123,10 +28718,14 @@
 /area/rogue/indoors/town)
 "lKP" = (
 /obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/mortar{
+	pixel_x = 2;
+	pixel_y = 19
+	},
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lKS" = (
 /turf/open/floor/rogue/church,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -28256,7 +28855,7 @@
 "lNG" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/closed,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lNY" = (
 /obj/structure/bars/passage/shutter{
 	desc = "Extremely strong. I don't think I can easily get through this with brute force. Where might the way to open it be?";
@@ -28419,6 +29018,14 @@
 "lRv" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"lRB" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lRE" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/greenstone,
@@ -28674,6 +29281,12 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
+"lXQ" = (
+/obj/machinery/light/rogue/torchholder/directional/west,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lXR" = (
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -28684,6 +29297,9 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"lYg" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lYo" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/blocks,
@@ -28983,7 +29599,7 @@
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mef" = (
 /obj/item/clothing/shoes/roguetown/boots,
 /turf/open/water/swamp,
@@ -29173,6 +29789,10 @@
 "miP" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/sewer)
+"miT" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mjd" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -29276,6 +29896,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"mma" = (
+/obj/structure/table/wood,
+/obj/item/cooking/platter,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mmb" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /turf/open/floor/rogue/tile{
@@ -29481,6 +30106,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
+"mqa" = (
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mqi" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -29562,6 +30192,16 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
+"mss" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "msF" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -29996,10 +30636,11 @@
 /area/rogue/under/town/basement)
 "mCg" = (
 /obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mCk" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/rooftop{
@@ -30027,6 +30668,12 @@
 "mCH" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"mCL" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mCR" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
 	pixel_y = 32
@@ -30046,6 +30693,10 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/old_ruin)
+"mDu" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mDy" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 1;
@@ -30144,6 +30795,12 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
+"mGK" = (
+/obj/structure/fluff/walldeco/chains{
+	icon_state = "chains4"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mGR" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/swamp/deep,
@@ -30171,6 +30828,12 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"mHd" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mHj" = (
 /obj/structure/bars/pipe{
 	dir = 1;
@@ -30296,6 +30959,13 @@
 "mJH" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
+"mKu" = (
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mKy" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -30359,6 +31029,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
+"mLS" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mMi" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/dirt,
@@ -30531,6 +31208,11 @@
 "mPn" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon/winding_halls)
+"mPo" = (
+/obj/structure/fluff/statue/knight/interior,
+/mob/living/simple_animal/hostile/rogue/skeleton/bow,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mPv" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -30724,6 +31406,13 @@
 /obj/machinery/anvil/crafted,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
+"mUr" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/item/reagent_containers/glass/bottle/rogue/strongpoison,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mUu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -31340,6 +32029,12 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/basement)
+"nfl" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nfq" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -31414,7 +32109,7 @@
 /turf/open/floor/rogue/greenstone{
 	dir = 4
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ngC" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -31602,6 +32297,12 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
+"nkb" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nkf" = (
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood{
@@ -32091,11 +32792,8 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains)
 "nsX" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/beach/forest)
+/turf/closed/mineral/random/rogue,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nsZ" = (
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -32129,6 +32827,14 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"ntT" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ntV" = (
 /obj/structure/roguemachine/scomm/directional/south,
 /turf/open/floor/rogue/ruinedwood{
@@ -32396,7 +33102,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nzW" = (
 /obj/structure/chair/bench/church/smallbench{
 	dir = 1
@@ -32500,6 +33206,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
+"nBH" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nBI" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /obj/item/burial_shroud{
@@ -33138,6 +33850,10 @@
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
+"nPj" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nPk" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -33330,6 +34046,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nUe" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
+/obj/machinery/light/rogue/torchholder/directional/east,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nUf" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grassred,
@@ -33350,6 +34074,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
+"nUx" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nUL" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt/road,
@@ -33704,6 +34436,16 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
+"odt" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
+"ody" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "odR" = (
 /obj/structure/closet/crate/drawer/random{
 	pixel_y = 0
@@ -34350,6 +35092,14 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"osg" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oso" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newbranch/leafless,
@@ -34838,6 +35588,12 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/abandoned_manor)
+"oBJ" = (
+/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oBL" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/table/wood{
@@ -34920,6 +35676,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"oDE" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oDG" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/west,
 /obj/structure/fluff/clock,
@@ -35018,6 +35780,10 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"oFV" = (
+/obj/structure/roguerock,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oFY" = (
 /mob/living/simple_animal/hostile/rogue/dragger,
 /turf/open/floor/rogue/dirt,
@@ -35105,6 +35871,15 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
+"oHb" = (
+/obj/item/restraints/legcuffs/beartrap,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oHg" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/newbranch/leafless{
@@ -35225,6 +36000,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"oKT" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oLh" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -35480,6 +36261,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"oRi" = (
+/obj/machinery/light/rogue/chand,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oRp" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -35544,6 +36329,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/dungeon/winding_halls)
+"oSK" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/obj/structure/fluff/alch,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oSW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -35637,10 +36430,12 @@
 /area/rogue/indoors/town)
 "oVo" = (
 /obj/structure/gate{
-	name = "Tsoridys' Mercy"
+	name = "Tsoridys' Mercy";
+	redstone_id = "bastilletop";
+	gid = "bastilletop"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oVs" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/east,
 /obj/effect/decal/wood/herringbone{
@@ -36408,6 +37203,10 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark)
+"plf" = (
+/obj/structure/mineral_door/wood/violet,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "plg" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/dirt,
@@ -36550,6 +37349,15 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"poC" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "poD" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/minotaur/axe,
 /turf/open/floor/rogue/cobblerock,
@@ -36674,7 +37482,7 @@
 /turf/open/floor/rogue/blocks/green{
 	dir = 4
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "prq" = (
 /obj/machinery/light/small{
 	mouse_opacity = 0;
@@ -36830,8 +37638,9 @@
 /obj/structure/stone_tile/slab/cracked{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pun" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/psycross,
@@ -37465,11 +38274,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
 "pGG" = (
-/obj/structure/mineral_door/wood,
+/obj/structure/mineral_door/wood{
+	locked = 1
+	},
 /turf/open/floor/rogue/greenstone{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pGH" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grasscold,
@@ -37539,6 +38350,9 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/garrison)
+"pIz" = (
+/turf/closed/mineral/random/rogue/med,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pIB" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -37593,6 +38407,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
+"pJh" = (
+/obj/structure/fluff/walldeco/chains{
+	icon_state = "chains2"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pJn" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/blocks/newstone,
@@ -37934,6 +38754,14 @@
 	},
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/town/basement)
+"pQV" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pQZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -38031,6 +38859,12 @@
 "pSz" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
+"pSI" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pSN" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -38081,7 +38915,7 @@
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 1
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pTF" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -38112,6 +38946,10 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pUy" = (
+/obj/item/chair/rogue/fancy,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "pUD" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt/road,
@@ -38305,6 +39143,10 @@
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"qas" = (
+/obj/item/storage/belt/rogue/pouch/coins/mid,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qaH" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
@@ -38809,6 +39651,10 @@
 /obj/item/clothing/under/roguetown/chainlegs/iron,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"qlS" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qmd" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -38894,6 +39740,12 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"qog" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/concrete{
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qok" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -38991,7 +39843,7 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qqD" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -39122,6 +39974,14 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"qte" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qti" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/beach)
@@ -39244,6 +40104,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"qwd" = (
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qwj" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -39452,6 +40315,14 @@
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dungeon/vulnafir)
+"qAr" = (
+/obj/structure/winch{
+	gid = "bastilletop";
+	redstone_id = "bastilletop";
+	name = "Tsoridys' Mercy"
+	},
+/turf/closed/mineral/random/rogue/high,
+/area/rogue/indoors/cave)
 "qAu" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39549,6 +40420,14 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/town/sewer)
+"qCJ" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qCP" = (
 /obj/structure/stairs{
 	dir = 1
@@ -39770,7 +40649,7 @@
 "qGD" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qGE" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 8
@@ -39851,6 +40730,14 @@
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dungeon/old_ruin)
+"qHT" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qHZ" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -40028,6 +40915,12 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"qKL" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qKX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -40097,6 +40990,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"qMM" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qMS" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /turf/open/floor/rogue/herringbone,
@@ -40313,7 +41212,7 @@
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qRV" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -40392,7 +41291,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qUj" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -40455,6 +41354,10 @@
 /obj/item/grown/log/tree/stake,
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
+"qWj" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qWm" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/carpet/stellar,
@@ -40569,6 +41472,10 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
+"qZe" = (
+/obj/machinery/light/rogue/torchholder/directional/south,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qZo" = (
 /turf/open/water/river{
 	icon_state = "rockwd"
@@ -41089,7 +41996,7 @@
 "rjm" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rjo" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "scary_manor3"
@@ -41167,6 +42074,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"rlM" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rlQ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -41177,6 +42089,12 @@
 "rlV" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/shelter/woods)
+"rlY" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/bow,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rmc" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -41648,7 +42566,7 @@
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rvj" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/axian_my_sweet,
@@ -41750,6 +42668,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
+"rxf" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rxg" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
@@ -41961,7 +42885,7 @@
 /turf/closed/wall/mineral/rogue/roofwall/innercorner{
 	dir = 4
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rCr" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
@@ -42344,6 +43268,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"rJv" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rJz" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/shelter)
@@ -42700,10 +43628,18 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"rRA" = (
+/obj/structure/mineral_door/wood/violet,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rRD" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"rRI" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rRP" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
@@ -42723,6 +43659,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"rSd" = (
+/obj/structure/table/wood,
+/obj/item/cooking/platter,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rSg" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/hexstone,
@@ -42783,6 +43726,14 @@
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
+"rTt" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rTB" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt/road,
@@ -42855,6 +43806,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/shop)
+"rUT" = (
+/obj/effect/decal/remains/wolf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rUU" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -43244,6 +44199,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/cave/dungeon/vulnafir)
+"ses" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sev" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -43326,6 +44290,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
+"sgq" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sgU" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/indoors/shelter/woods)
@@ -44170,6 +45140,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"sxD" = (
+/obj/structure/table/optable,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sxT" = (
 /turf/closed/wall/mineral/rogue/decostone/end,
 /area/rogue/indoors/town)
@@ -44408,6 +45384,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
+"sDo" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sDz" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/north,
 /turf/open/floor/rogue/churchbrick,
@@ -44544,6 +45526,12 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"sHz" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sHF" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -44605,6 +45593,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
+"sJe" = (
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/torchholder/directional/north,
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sJf" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -44662,6 +45655,16 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"sKy" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bucket/pot{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sKB" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44729,6 +45732,11 @@
 "sLn" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"sLv" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sLV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -44773,11 +45781,11 @@
 /area/rogue/indoors/town/shop)
 "sMF" = (
 /obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
+	icon_state = "map4"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/cave)
+/obj/item/cooking/platter,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sMJ" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/dirt/road,
@@ -44823,6 +45831,12 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
+"sNB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sNZ" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
@@ -45148,7 +46162,7 @@
 /area/rogue/indoors)
 "sVG" = (
 /turf/closed/wall/mineral/rogue/stone/window,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sVK" = (
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -45234,6 +46248,14 @@
 /obj/structure/fluff/walldeco/barbersignreverse,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/town)
+"sYF" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sYM" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -45335,6 +46357,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
+"tav" = (
+/obj/item/storage/belt/rogue/pouch/coins/poor,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "taz" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -46922,6 +47948,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
+"tLg" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tLu" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/bog)
@@ -47077,6 +48107,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
+"tOA" = (
+/obj/structure/bed/rogue/inn/wool,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tOB" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/outdoors/town)
@@ -47207,10 +48243,11 @@
 /obj/structure/bed/rogue/shit{
 	name = "makeshift bed"
 	},
+/obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tSE" = (
 /obj/machinery/light/rogue/torchholder/directional/west,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -47247,6 +48284,13 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"tTc" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tTf" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
@@ -48487,6 +49531,12 @@
 "usY" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/winding_halls)
+"utc" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "utf" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -49039,10 +50089,11 @@
 	dir = 5;
 	icon_state = "largetable"
 	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uEy" = (
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/cobble,
@@ -49072,7 +50123,7 @@
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uFd" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement)
@@ -49452,6 +50503,12 @@
 /obj/structure/roguemachine/scomm/directional/west,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
+"uNe" = (
+/obj/machinery/light/rogue/torchholder/directional/south,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uNj" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -49832,8 +50889,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "uVt" = (
+/obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uVN" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -50386,6 +51444,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"vhA" = (
+/obj/machinery/light/rogue/torchholder/directional/east,
+/obj/item/cooking/platter,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vhE" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -51332,11 +52397,10 @@
 /area/rogue/indoors/town)
 "vDS" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	icon_state = "map3"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/cave)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vDV" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
@@ -51380,10 +52444,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "vEG" = (
+/obj/structure/mineral_door/wood/violet,
 /turf/open/floor/rogue/greenstone{
 	dir = 1
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vEO" = (
 /obj/item/rogueweapon/shield/wood/crafted{
 	pixel_y = 32
@@ -51461,10 +52526,11 @@
 /area/rogue/indoors/town)
 "vGh" = (
 /obj/structure/closet/crate/chest/old_crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vGx" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -51934,6 +53000,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"vRr" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vRF" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road,
@@ -52126,11 +53198,14 @@
 /area/rogue/outdoors/beach/forest)
 "vUY" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 2
+	icon_state = "map2"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/cave)
+/obj/item/reagent_containers/glass/cup/golden/poison{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vUZ" = (
 /obj/structure/roguemachine/scomm/directional/west,
 /turf/open/floor/rogue/wood/herringbone,
@@ -52180,6 +53255,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"vWv" = (
+/obj/structure/mineral_door/wood/violet,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vWC" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/beach/forest)
@@ -52386,8 +53467,8 @@
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/indoors/town/church/chapel)
 "vZY" = (
-/turf/closed/wall/mineral/rogue/stone/window,
-/area/rogue/indoors/cave)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "waz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -52623,7 +53704,7 @@
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wgL" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -53171,6 +54252,12 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"wsC" = (
+/obj/item/chair/rogue/crafted,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wsD" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/head/roguetown/roguehood/black,
@@ -53324,6 +54411,13 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"wvA" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wvC" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
@@ -53331,6 +54425,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/old_ruin)
+"wvO" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wvP" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -53490,6 +54591,11 @@
 /obj/effect/mapping_helpers/access/garrison/armory,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"wAW" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wBc" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/east,
 /turf/open/floor/rogue/hexstone,
@@ -53541,7 +54647,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wCB" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -53861,6 +54967,10 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
+"wJW" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/beach/forest)
 "wKc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/concrete{
@@ -53932,6 +55042,10 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/abandoned_manor)
+"wNn" = (
+/obj/item/roguegem/random,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wNv" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/town/basement)
@@ -54067,6 +55181,12 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"wQI" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wQO" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -54108,11 +55228,14 @@
 /area/rogue/outdoors/woods)
 "wRj" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	icon_state = "map1"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/cave)
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wRq" = (
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/dirt/road,
@@ -54230,6 +55353,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/basement)
+"wUP" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wVh" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/tile,
@@ -54251,6 +55380,14 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
+"wVY" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "wWh" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -54428,6 +55565,12 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains)
+"xas" = (
+/mob/living/simple_animal/hostile/rogue/skeleton,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xaA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -54520,6 +55663,12 @@
 "xcv" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/town/basement)
+"xcw" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xcz" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/roguebag{
@@ -55042,6 +56191,13 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"xlS" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xlY" = (
 /obj/structure/toilet,
 /obj/effect/decal/cobbleedge{
@@ -55056,7 +56212,7 @@
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
-/area/rogue/indoors/cave)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xma" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -55495,6 +56651,13 @@
 /obj/machinery/light/rogue/torchholder/directional/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"xuW" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xvm" = (
 /obj/structure/curtain/bounty{
 	color = "grey"
@@ -56112,6 +57275,13 @@
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"xJR" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xJW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -56315,6 +57485,10 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"xPa" = (
+/obj/effect/decal/remains/wolf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/beach/forest)
 "xPc" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/naturalstone,
@@ -56763,7 +57937,7 @@
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
-/area/rogue/outdoors/beach/forest)
+/area/rogue/under/cave/dungeon/fort_dusk)
 "yaK" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -112102,8 +113276,8 @@ onF
 onF
 onF
 onF
-onF
-onF
+fnC
+fnC
 onF
 onF
 onF
@@ -112554,10 +113728,10 @@ onF
 onF
 onF
 onF
-onF
-onF
-onF
-onF
+fnC
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -113008,6 +114182,9 @@ onF
 onF
 onF
 onF
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -113021,11 +114198,8 @@ onF
 onF
 onF
 onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
 onF
 onF
 onF
@@ -113461,6 +114635,8 @@ onF
 onF
 onF
 onF
+fnC
+fnC
 onF
 onF
 onF
@@ -113473,12 +114649,10 @@ onF
 onF
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -113914,6 +115088,7 @@ onF
 onF
 onF
 onF
+fnC
 onF
 onF
 onF
@@ -113926,11 +115101,10 @@ onF
 onF
 onF
 onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -114365,6 +115539,8 @@ onF
 onF
 onF
 onF
+fnC
+fnC
 onF
 onF
 onF
@@ -114372,18 +115548,16 @@ onF
 onF
 onF
 onF
+fnC
+fnC
 onF
 onF
 onF
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -114816,6 +115990,8 @@ onF
 onF
 onF
 onF
+fnC
+fnC
 onF
 onF
 onF
@@ -114823,19 +115999,17 @@ onF
 onF
 onF
 onF
+fnC
+fnC
+fnC
 onF
 onF
 onF
 onF
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
 onF
 onF
 onF
@@ -115268,6 +116442,7 @@ onF
 onF
 onF
 onF
+fnC
 onF
 onF
 onF
@@ -115277,17 +116452,16 @@ onF
 onF
 onF
 onF
+fnC
+fnC
+fnC
 onF
 onF
 onF
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
 onF
 onF
 onF
@@ -115720,6 +116894,7 @@ onF
 onF
 onF
 onF
+fnC
 onF
 onF
 onF
@@ -115731,15 +116906,14 @@ onF
 onF
 onF
 onF
+fnC
+fnC
 onF
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -116172,6 +117346,7 @@ onF
 onF
 onF
 onF
+fnC
 onF
 onF
 onF
@@ -116184,13 +117359,12 @@ onF
 onF
 onF
 onF
+fnC
+fnC
 onF
-onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -116610,6 +117784,13 @@ uXv
 ujm
 ujm
 onF
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
 onF
 onF
 onF
@@ -116617,6 +117798,13 @@ onF
 onF
 onF
 onF
+fnC
+fnC
+onF
+onF
+onF
+fnC
+fnC
 onF
 onF
 onF
@@ -116624,24 +117812,10 @@ onF
 onF
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -117062,6 +118236,13 @@ uXv
 ujm
 ujm
 onF
+vZY
+jFO
+lAA
+gFf
+qog
+jFO
+vZY
 onF
 onF
 onF
@@ -117070,20 +118251,13 @@ onF
 onF
 onF
 onF
+fnC
+fnC
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+fnC
+fnC
+fnC
+fnC
 onF
 tsB
 tsB
@@ -117092,7 +118266,7 @@ tsB
 tsB
 tsB
 onF
-onF
+fnC
 onF
 onF
 onF
@@ -117514,37 +118688,37 @@ uXv
 ujm
 ujm
 onF
+vZY
+oDE
+qwd
+irB
+gFf
+kZp
+vZY
+fnC
+fnC
+fnC
+onF
+fnC
+fnC
 onF
 onF
 onF
+fnC
+fnC
+fnC
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+tsB
+tsB
+fnC
+fnC
 tsB
 tsB
 tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-onF
+fnC
 onF
 onF
 onF
@@ -117966,37 +119140,37 @@ uXv
 ujm
 ujm
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+gFf
+irB
+mDu
+eDg
+gFf
+vZY
+vVd
+vVd
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
 onF
 onF
 tsB
 tsB
 tsB
 tsB
+fnC
+fnC
 tsB
 tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-onF
+fnC
 onF
 onF
 onF
@@ -118418,16 +119592,16 @@ uXv
 ujm
 ujm
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+baC
+gFf
+eDg
+wNn
+lAA
+vZY
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -118440,16 +119614,16 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
+fnC
+fnC
+fnC
+fnC
+fnC
 qPv
-qPv
-qPv
-qPv
 tsB
 tsB
-tsB
-onF
+fnC
+fnC
 onF
 onF
 onF
@@ -118870,13 +120044,13 @@ uXv
 ujm
 ujm
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+odt
+iDX
+vZY
+oDE
+jFO
+vZY
 onF
 onF
 onF
@@ -118891,19 +120065,19 @@ onF
 tsB
 tsB
 tsB
-tsB
+fnC
+fnC
 qPv
 qPv
 qPv
-qPv
-qPv
-qPv
-qPv
-qPv
-tsB
-tsB
-tsB
-onF
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
 onF
 onF
 onF
@@ -119322,13 +120496,13 @@ uXv
 ujm
 ujm
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
 onF
 onF
 onF
@@ -119342,7 +120516,8 @@ onF
 onF
 tsB
 tsB
-tsB
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -119351,12 +120526,11 @@ qPv
 qPv
 qPv
 qPv
-qPv
-tsB
-tsB
 tsB
 tsB
 tsB
+fnC
+fnC
 onF
 onF
 onF
@@ -119793,7 +120967,8 @@ onF
 onF
 onF
 tsB
-tsB
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -119804,11 +120979,10 @@ qPv
 qPv
 qPv
 qPv
-qPv
-tsB
-tsB
 tsB
 tsB
+fnC
+fnC
 tsB
 tsB
 onF
@@ -120243,9 +121417,9 @@ onF
 onF
 onF
 onF
-tsB
-tsB
-tsB
+fnC
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -120260,9 +121434,9 @@ qPv
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
+fnC
+fnC
+fnC
 tsB
 onF
 onF
@@ -120694,10 +121868,10 @@ onF
 onF
 onF
 onF
-tsB
-tsB
-tsB
-tsB
+fnC
+fnC
+fnC
+fnC
 qPv
 qPv
 tsB
@@ -120713,16 +121887,16 @@ qPv
 tsB
 tsB
 tsB
+fnC
+fnC
+fnC
+fnC
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+fnC
+fnC
+fnC
+fnC
+fnC
 tsB
 tsB
 tsB
@@ -121147,10 +122321,10 @@ onF
 onF
 onF
 tsB
-tsB
-tsB
-qPv
-qPv
+fnC
+fnC
+fnC
+fnC
 qPv
 tsB
 tsB
@@ -121168,14 +122342,14 @@ tsB
 tsB
 tsB
 tsB
+fnC
+fnC
+fnC
+fnC
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+fnC
+fnC
 tsB
 tsB
 tsB
@@ -121600,8 +122774,8 @@ tsB
 tsB
 tsB
 tsB
-tsB
-qPv
+fnC
+fnC
 qPv
 qPv
 tsB
@@ -121627,7 +122801,7 @@ tsB
 tsB
 tsB
 tsB
-tsB
+fnC
 tsB
 tsB
 tsB
@@ -122079,8 +123253,8 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
+fnC
+fnC
 tsB
 qPv
 qPv
@@ -122532,7 +123706,7 @@ tsB
 tsB
 tsB
 tsB
-tsB
+fnC
 tsB
 qPv
 qPv
@@ -122984,7 +124158,7 @@ tsB
 tsB
 tsB
 tsB
-qPv
+fnC
 qPv
 qPv
 qPv
@@ -123436,7 +124610,7 @@ qPv
 qPv
 qPv
 qPv
-qPv
+fnC
 qPv
 qPv
 qPv
@@ -123888,8 +125062,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 tsB
@@ -124341,7 +125515,7 @@ qPv
 qPv
 qPv
 qPv
-qPv
+fnC
 qPv
 qPv
 tsB
@@ -124793,10 +125967,10 @@ qPv
 qPv
 qPv
 tsB
-tsB
-qPv
-qPv
-tsB
+fnC
+fnC
+fnC
+fnC
 tsB
 tsB
 tsB
@@ -125248,9 +126422,9 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
+fnC
+fnC
+fnC
 tsB
 qPv
 qPv
@@ -125702,7 +126876,7 @@ tsB
 onF
 onF
 onF
-tsB
+fnC
 tsB
 tsB
 qPv
@@ -126154,8 +127328,8 @@ onF
 onF
 onF
 onF
-onF
-tsB
+fnC
+fnC
 tsB
 qPv
 qPv
@@ -126607,8 +127781,8 @@ onF
 onF
 onF
 onF
-tsB
-tsB
+fnC
+fnC
 tsB
 qPv
 acF
@@ -127060,10 +128234,10 @@ onF
 onF
 onF
 onF
-tsB
-tsB
-qPv
-qPv
+fnC
+fnC
+fnC
+fnC
 acF
 acF
 tIH
@@ -231871,13 +233045,13 @@ ogs
 qmf
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
 onF
 onF
 onF
@@ -232323,13 +233497,13 @@ ogs
 qmf
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+gPf
+dhA
+nUx
+fAh
+wVY
+vZY
 onF
 onF
 onF
@@ -232775,13 +233949,13 @@ ogs
 qmf
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+xlZ
+cwy
+bBf
+cwy
+qHT
+vZY
 onF
 onF
 onF
@@ -233227,13 +234401,13 @@ ogs
 qmf
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+vZY
+cwy
+cwy
+pJh
+fix
+vZY
 onF
 onF
 onF
@@ -233679,13 +234853,13 @@ ogs
 qmf
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+vZY
+mGK
+cwy
+cwy
+oHb
+vZY
 onF
 onF
 onF
@@ -234131,13 +235305,13 @@ ogs
 qmf
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+vZY
+cwy
+vRr
+lRB
+auT
+vZY
 onF
 onF
 onF
@@ -234583,13 +235757,13 @@ ogs
 qmf
 onF
 onF
-onF
-onF
-onF
-onF
-onF
-onF
-onF
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
 onF
 onF
 onF
@@ -240018,7 +241192,7 @@ onF
 onF
 onF
 onF
-onF
+qAr
 onF
 onF
 onF
@@ -345779,14 +346953,14 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+pIz
+pIz
+pIz
+pIz
+pIz
+pIz
+vZY
+vZY
 tsB
 tsB
 tsB
@@ -346231,14 +347405,14 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+pIz
+lrX
+lYg
+lYg
+lYg
+aSY
+rxf
+vZY
 tsB
 tsB
 tsB
@@ -346683,21 +347857,21 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-oPv
-oPv
-oPv
-oPv
-oPv
+pIz
+lYg
+lYg
+nPj
+lYg
+gPf
+lYg
+vZY
+pIz
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
 tsB
 tsB
 tsB
@@ -347135,26 +348309,21 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-vlj
-vlj
-vlj
-vlj
-oPv
-tsB
-tsB
-tsB
-tsB
-tsB
+pIz
+wvO
+lYg
+gPf
+xlS
+gPf
+uNe
+vZY
+vZY
+vZY
+khZ
+mUr
+bzl
+mPo
+vZY
 tsB
 tsB
 tsB
@@ -347167,6 +348336,11 @@ tsB
 tsB
 tsB
 tsB
+tsB
+hxw
+fnC
+fnC
+fnC
 tsB
 tsB
 tsB
@@ -347584,6 +348758,25 @@ ogs
 qmf
 tsB
 tsB
+vZY
+vZY
+vZY
+vZY
+gPf
+gPf
+gPf
+xJR
+lYg
+gPf
+hmS
+vZY
+vZY
+bzl
+bzl
+pSI
+bzl
+vZY
+vZY
 tsB
 tsB
 tsB
@@ -347591,34 +348784,15 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-oPv
-vlj
-vlj
-vlj
-vlj
-oPv
-oPv
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+hxw
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
 tsB
 tsB
 tsB
@@ -348035,26 +349209,26 @@ ogs
 (134,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-vlj
-vlj
+vZY
+vZY
+eLG
+vZY
+vZY
+oBJ
+gPf
+gPf
+lYg
+gPf
+gPf
+gPf
+ntT
+bzl
+pUy
 sMF
 wRj
-vlj
-vlj
-oPv
+bzl
+cJl
+vZY
 tsB
 tsB
 tsB
@@ -348062,15 +349236,15 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
 tsB
 tsB
 tsB
@@ -348487,26 +349661,26 @@ ogs
 (135,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-vlj
-vlj
+vZY
+dmh
+xlZ
+eUn
+vZY
+vZY
+ntT
+vZY
+vZY
+lYg
+vZY
+vZY
+vZY
+tLg
+loH
 ggA
 vUY
-vlj
-vlj
-oPv
+lip
+qZe
+vZY
 tsB
 tsB
 tsB
@@ -348514,16 +349688,16 @@ tsB
 tsB
 tsB
 tsB
+fnC
+fnC
 tsB
 tsB
 tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
+fnC
+fnC
 tsB
 tsB
 tsB
@@ -348939,43 +350113,43 @@ ogs
 (136,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-oPv
-oPv
-vlj
-vlj
+vZY
+gPf
+gPf
+gPf
+vZY
+gPf
+gPf
+vZY
+mLS
+lYg
+vZY
+vZY
+hjk
+bzl
+bzl
 cVK
 vDS
-vlj
-vlj
-oPv
-oPv
-oPv
+wQI
+bzl
+vZY
+vZY
+vZY
 tsB
 tsB
 tsB
 tsB
 tsB
-tsB
-tsB
+fnC
+fnC
 tsB
 tsB
 qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -349391,43 +350565,43 @@ ogs
 (137,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
+vZY
+tTc
+gPf
+gPf
+vWv
+gPf
+gPf
+vZY
+fqu
+lYg
+vZY
 gfT
-vlj
-vlj
-vlj
-vlj
-vlj
-vlj
-vlj
-vlj
-vlj
+bzl
+bzl
+bzl
+bzl
+bzl
+bzl
+bzl
+bzl
+sDo
+fnC
+fnC
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+fnC
+fnC
+fnC
+fnC
+fnC
 tsB
 tsB
 qPv
 qPv
 qPv
-qPv
-qPv
-qPv
+fnC
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -349843,41 +351017,41 @@ ogs
 (138,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
+vZY
+dZM
+hhd
+gPf
+vZY
+gPf
+pQV
+vZY
+mHd
+aSY
+vZY
 gfT
-vlj
-vlj
-vlj
-vlj
-vlj
-vlj
-vlj
-vlj
-vlj
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+bzl
+bzl
+sLv
+bzl
+bzl
+aiL
+bzl
+rRI
+vZY
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
 tsB
 qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -350295,27 +351469,27 @@ ogs
 (139,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-oPv
-vVd
-vlj
-oPv
-oPv
-oPv
-oPv
-vVd
-vlj
-oPv
+vZY
+vZY
+vZY
+vZY
+vZY
+cvb
+gPf
+vZY
+gia
+lYg
+vZY
+vZY
+cxa
+bzl
+vZY
+qWj
+qWj
+vZY
+gPf
+bzl
+vZY
 oPv
 tsB
 tsB
@@ -350328,8 +351502,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -350747,27 +351921,27 @@ ogs
 (140,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-vVd
-vlj
-oPv
-oPv
-oPv
-oPv
-vVd
-oPv
-oPv
+vZY
+vZY
+vZY
+vZY
+vZY
+fnG
+gPf
+vZY
+vZY
+vZY
+vZY
+krm
+gPf
+bzl
+vZY
+vZY
+vZY
+vZY
+ntT
+vZY
+vZY
 tsB
 tsB
 tsB
@@ -350781,8 +351955,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -351199,27 +352373,27 @@ ogs
 (141,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-vVd
-vlj
-oPv
-vVd
-vVd
-vVd
-vVd
-vlj
-oPv
+vZY
+utc
+wvA
+utc
+bfo
+gPf
+gPf
+gPf
+gPf
+gPf
+gPf
+gPf
+gPf
+bzl
+vZY
+aUl
+sHz
+gPf
+gPf
+ddf
+vZY
 qPv
 qPv
 qPv
@@ -351233,8 +352407,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -351651,31 +352825,31 @@ ogs
 (142,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-vVd
-vlj
-oPv
-vVd
-vVd
-vVd
-vVd
-vlj
-oPv
-oPv
-oPv
-oPv
-oPv
+vZY
+iwp
+gPf
+gPf
+gPf
+gPf
+gPf
+egW
+gPf
+bmj
+gPf
+egW
+gPf
+bzl
+vZY
+hfU
+gPf
+wsC
+gPf
+bzl
+vZY
+vZY
+vZY
+vZY
+vZY
 qPv
 qPv
 qPv
@@ -352103,30 +353277,30 @@ ogs
 (143,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
+vZY
+oSK
+gPf
+sxD
+xuW
+gPf
+gPf
+vZY
+eBC
+vZY
+eBC
+vZY
 xlZ
 jCq
-oPv
-vVd
-vVd
-vVd
-vVd
-vlj
+vZY
+hNN
+gPf
+sKy
+rSd
+bzl
 lbV
+jiW
 lbV
-lbV
-lbV
+lqL
 lbV
 qPv
 qPv
@@ -352555,30 +353729,30 @@ ogs
 (144,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-oPv
-oPv
-oPv
-vVd
-vVd
-vVd
-vVd
-vlj
+vZY
+iqj
+rlY
+gPf
+fYs
+gPf
+gPf
+vZY
+pIz
+pIz
+pIz
+vZY
+vZY
+vZY
+vZY
+jLb
+gPf
+gfg
+gPf
+bzl
 lbV
-lbV
-lbV
-lbV
+mKu
+nkb
+hyg
 qPv
 qPv
 qPv
@@ -353007,30 +354181,30 @@ ogs
 (145,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-oPv
-oPv
-oPv
-oPv
-vlj
-oPv
-oPv
-oPv
-oPv
+vZY
+buk
+utc
+utc
+wUP
+gPf
+pQV
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+kFr
+vZY
+vZY
+vZY
+vZY
 qPv
 qPv
 dCq
@@ -353459,30 +354633,30 @@ ogs
 (146,1,3) = {"
 qmf
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-vVd
-vVd
-vVd
-vVd
-vlj
-oPv
-vVd
-vlj
-oPv
+vZY
+vZY
+vZY
+vZY
+vZY
+cxa
+gPf
+vZY
+bcK
+sHz
+mss
+iLc
+cOk
+gPf
+gPf
+gPf
+gPf
+gPf
+gPf
+bzl
+vZY
+gTQ
+wAW
+vZY
 qPv
 dCq
 dCq
@@ -353915,26 +355089,26 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-vVd
-vVd
-vVd
-vVd
-vlj
-vlj
-vVd
-vlj
-oPv
+vZY
+gPf
+gPf
+ntT
+gPf
+gPf
+gPf
+gPf
+gPf
+gPf
+wUP
+gPf
+wUP
+gPf
+gPf
+bzl
+kFr
+sgq
+bzl
+vZY
 qPv
 dCq
 dCq
@@ -354367,26 +355541,26 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-oPv
-oPv
-oPv
-vVd
-vlj
-oPv
-vVd
-vlj
 vZY
+vZY
+vZY
+vZY
+gPf
+gPf
+xcw
+gPf
+gPf
+vZY
+vZY
+fJw
+vZY
+vZY
+poC
+rJv
+vZY
+hoH
+hsc
+sVG
 dCq
 dCq
 dCq
@@ -354822,23 +355996,23 @@ tsB
 tsB
 tsB
 tsB
+vZY
+osg
+tOA
+nUe
+tOA
+gms
+vZY
 tsB
+fnC
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-oPv
-oPv
-oPv
-oPv
-oPv
-oPv
-oPv
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
 dCq
 dCq
 qPv
@@ -355274,15 +356448,15 @@ tsB
 tsB
 tsB
 tsB
+vZY
+vZY
+vZY
+vZY
+pIz
+vZY
+vZY
 tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
-tsB
+fnC
 tsB
 tsB
 sJx
@@ -355734,8 +356908,8 @@ tsB
 tsB
 tsB
 tsB
-tsB
-tsB
+fnC
+fnC
 tsB
 tsB
 qPv
@@ -356187,7 +357361,7 @@ tsB
 tsB
 tsB
 tsB
-qPv
+fnC
 qPv
 qPv
 qPv
@@ -356639,7 +357813,7 @@ tsB
 tsB
 tsB
 qPv
-qPv
+fnC
 qPv
 qPv
 qPv
@@ -357088,10 +358262,10 @@ tsB
 tsB
 qPv
 qPv
-qPv
-qPv
-qPv
-qPv
+fnC
+fnC
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -357540,8 +358714,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -357992,8 +359166,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -358443,8 +359617,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -358895,8 +360069,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -359347,7 +360521,7 @@ qPv
 qPv
 qPv
 qPv
-qPv
+fnC
 qPv
 qPv
 qPv
@@ -359799,8 +360973,8 @@ qPv
 qPv
 qPv
 qPv
-qPv
-qPv
+fnC
+fnC
 qPv
 qPv
 qPv
@@ -360252,7 +361426,7 @@ qPv
 qPv
 qPv
 qPv
-qPv
+fnC
 qPv
 qPv
 dCq
@@ -360704,7 +361878,7 @@ jrj
 qPv
 qPv
 qPv
-qPv
+fnC
 dCq
 dCq
 dCq
@@ -461048,11 +462222,11 @@ gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
+nsX
+nsX
+nsX
+nsX
+nsX
 gTH
 gTH
 gTH
@@ -461488,24 +462662,24 @@ ogs
 (130,1,4) = {"
 gBM
 gBM
+nsX
+nsX
+nsX
+lYg
+lYg
+lYg
+nsX
 gTH
 gTH
 gTH
 gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-hRy
-hRy
-hRy
-gTH
-gTH
+nsX
+nsX
+rlM
+fWH
+gLz
+nsX
+nsX
 gTH
 gTH
 gTH
@@ -461940,27 +463114,27 @@ ogs
 (131,1,4) = {"
 gBM
 gBM
+nsX
+nsX
+lYg
+lYg
+nsX
+lYg
+nsX
+nsX
 gTH
 gTH
-gTH
-dCq
-dCq
-dCq
-gTH
-gTH
-gTH
-gTH
-gTH
-gTH
-dCq
-lNa
+nsX
+nsX
+oFV
+cUW
 iFL
-xEG
-xEG
-gTH
-gTH
-gTH
-gTH
+sNB
+sNB
+nsX
+nsX
+nsX
+nsX
 gTH
 gTH
 gTH
@@ -462392,27 +463566,27 @@ ogs
 (132,1,4) = {"
 gBM
 gBM
-gTH
-dCq
-dCq
-gTH
-gTH
-hRy
-hRy
-gTH
-gTH
-gTH
-gTH
-gTH
-dCq
-lNa
-vMR
-vMR
-vMR
-vMR
-lNa
-hRy
-gTH
+nsX
+lYg
+lYg
+nsX
+nsX
+fYe
+fWH
+nsX
+nsX
+nsX
+nsX
+nsX
+lYg
+hQp
+cwy
+cwy
+cwy
+cwy
+nfl
+bkx
+nsX
 gTH
 gTH
 gTH
@@ -462844,27 +464018,27 @@ ogs
 (133,1,4) = {"
 gBM
 gBM
-gTH
-dCq
-dCq
-gTH
-hRy
-fwS
-hRy
-gTH
-gTH
-dCq
-dCq
-dCq
-dCq
-lNa
-vMR
-vMR
-vMR
-vMR
-lNa
-hRy
-fwS
+nsX
+lYg
+nsX
+nsX
+fWH
+vZY
+qlS
+nsX
+nsX
+lYg
+lYg
+lYg
+lYg
+hQp
+cwy
+hKx
+cwy
+cwy
+nfl
+hWC
+vZY
 gTH
 gTH
 gTH
@@ -463296,27 +464470,27 @@ ogs
 (134,1,4) = {"
 gBM
 gBM
-gTH
-dCq
-dCq
-fwS
-hRy
-hRy
-hRy
-hRy
-dCq
-dCq
-dCq
-gTH
-dCq
-lNa
-vMR
-vMR
-vMR
-vMR
-lNa
-hRy
-fwS
+nsX
+lYg
+rUT
+vZY
+qas
+fWH
+fuo
+fWH
+lYg
+lYg
+oFV
+nsX
+lYg
+hQp
+cwy
+cwy
+cwy
+cwy
+nfl
+iwR
+vZY
 gTH
 gTH
 gTH
@@ -463748,27 +464922,27 @@ ogs
 (135,1,4) = {"
 gBM
 gBM
-gTH
-dCq
-gTH
-gTH
-hRy
-hRy
-hRy
-hRy
-dCq
-gTH
-gTH
-gTH
-hRy
-lNa
-vMR
-vMR
-vMR
-vMR
-lNa
-hRy
-fwS
+nsX
+lYg
+nsX
+nsX
+fWH
+fWH
+hBp
+fWH
+lYg
+nsX
+nsX
+nsX
+fYe
+hQp
+cwy
+cwy
+cwy
+cwy
+nfl
+fWH
+vZY
 gTH
 gTH
 gTH
@@ -464200,33 +465374,33 @@ ogs
 (136,1,4) = {"
 gBM
 gBM
+aHe
+lYg
+nsX
+vZY
+fWH
+vZY
+fWH
+fWH
+vZY
+vZY
+vZY
+vZY
+vZY
+hQp
+cwy
+cwy
+cwy
+cwy
+nfl
+fWH
+vZY
+vZY
+nsX
+vZY
+vZY
 dCq
-dCq
-gTH
-fwS
-hRy
-fwS
-hRy
-hRy
-fwS
-fwS
-fwS
-fwS
-fwS
-lNa
-vMR
-vMR
-vMR
-vMR
-lNa
-hRy
-hRy
-hRy
-hRy
-gTH
-gTH
-dCq
-dCq
+xPa
 dCq
 dCq
 dCq
@@ -464652,31 +465826,31 @@ ogs
 (137,1,4) = {"
 gBM
 gBM
-gTH
-dCq
-gTH
-fwS
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
 nsX
-vMR
-fwS
-lNa
-vMR
-vMR
-vMR
-vMR
-lNa
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
+hsZ
+nsX
+vZY
+eaI
+mma
+fWH
+fWH
+fWH
+fWH
+gfT
+cwy
+vZY
+sJe
+cwy
+oRi
+cwy
+cwy
+nfl
+fWH
+fWH
+jFW
+fWH
+fWH
+rRA
 dCq
 gTH
 dCq
@@ -465104,31 +466278,31 @@ ogs
 (138,1,4) = {"
 gBM
 gBM
-gTH
-gTH
-gTH
-fwS
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
 nsX
-vMR
-fwS
-lNa
-vMR
-vMR
-vMR
-vMR
-lNa
-hRy
-hRy
-hRy
-hRy
-hRy
-gTH
+nsX
+nsX
+vZY
+jFW
+fWH
+fWH
+fWH
+fWH
+fWH
+gfT
+cwy
+vZY
+hgr
+cwy
+cwy
+cwy
+cwy
+nfl
+fWH
+fWH
+fWH
+fWH
+fWH
+vZY
 gTH
 gTH
 gTH
@@ -465556,31 +466730,31 @@ ogs
 (139,1,4) = {"
 gBM
 gBM
-gTH
-gTH
-gTH
-fwS
-hRy
-fwS
-hRy
-hRy
-fwS
-fwS
-fwS
-fwS
-fwS
-lNa
-xEG
-xEG
-xEG
-xEG
-lNa
-hRy
-fwS
-gTH
-gTH
-gTH
-gTH
+nsX
+nsX
+nsX
+vZY
+eaI
+vZY
+qlS
+fWH
+vZY
+vZY
+vZY
+vZY
+vZY
+gvf
+qMM
+qMM
+qMM
+qMM
+bhv
+fWH
+vZY
+nsX
+nsX
+vZY
+vZY
 gTH
 gTH
 gTH
@@ -466008,27 +467182,27 @@ ogs
 (140,1,4) = {"
 gBM
 gBM
-gTH
-gTH
-gTH
-fwS
-hRy
-hRy
-hRy
-hRy
-fwS
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
-hRy
-fwS
+nsX
+nsX
+nsX
+vZY
+fWH
+fWH
+fWH
+fWH
+vZY
+nsX
+nsX
+fWH
+fWH
+fWH
+fWH
+fWH
+fWH
+fWH
+fWH
+hWC
+vZY
 gTH
 gTH
 gTH
@@ -466460,27 +467634,27 @@ ogs
 (141,1,4) = {"
 gBM
 gBM
-fwS
-fwS
-fwS
-fwS
-fwS
-fwS
-fwS
-fwS
-fwS
-hRy
-hRy
-hRy
-hRy
-hRy
-gTH
-gTH
-gTH
-gTH
-dCq
-dCq
-fwS
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+nsX
+nsX
+nsX
+fWH
+fYe
+nsX
+nsX
+nsX
+vZY
+vZY
+ody
+vZY
 gTH
 gTH
 gTH
@@ -466912,27 +468086,27 @@ ogs
 (142,1,4) = {"
 gBM
 gBM
-fwS
+vZY
 tSD
-lSw
+mqa
 wgH
-lSw
+mqa
 uEw
 aJD
-vGh
-fwS
-fwS
-fwS
-fwS
-fwS
-fwS
-fwS
-gTH
-gTH
-gTH
-gTH
-dCq
-gTH
+qCJ
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+nsX
+nsX
+nsX
+nsX
+mCL
+nsX
 gTH
 gTH
 gTH
@@ -467364,27 +468538,27 @@ ogs
 (143,1,4) = {"
 gBM
 gBM
-fwS
+vZY
 bUj
-lSw
+xas
 rva
-lSw
-lSw
-lSw
-lSw
+mqa
+fQf
+aKk
+mqa
 rva
-lSw
+mqa
 bUj
-fwS
-vMR
-vMR
-fwS
-gTH
-ubW
-gTH
-gTH
-dCq
-dCq
+vZY
+cwy
+cwy
+vZY
+nsX
+ioP
+nsX
+nsX
+oFV
+lYg
 gTH
 gTH
 gTH
@@ -467816,27 +468990,27 @@ ogs
 (144,1,4) = {"
 gBM
 gBM
-fwS
-fwS
-fwS
-fwS
+vZY
+vZY
+vZY
+vZY
 lKP
-lSw
-lSw
-lSw
+vhA
+mqa
+mqa
 wgH
-lSw
-tSD
-fwS
+xas
+sYF
+vZY
 mec
-mec
-fwS
-dCq
-dCq
-gTH
-gTH
-gTH
-dCq
+aeh
+vZY
+lYg
+lYg
+nsX
+nsX
+nsX
+lYg
 gTH
 gTH
 gTH
@@ -468268,27 +469442,27 @@ ogs
 (145,1,4) = {"
 gBM
 gBM
-fwS
+vZY
 vGh
-lSw
-fwS
-fwS
-fwS
+mqa
+vZY
+vZY
+vZY
 duu
-fwS
-fwS
-fwS
-fwS
-fwS
-lSw
-lSw
-fwS
-ubW
-dCq
-dCq
-gTH
-dCq
-dCq
+vZY
+vZY
+vZY
+vZY
+vZY
+mqa
+mqa
+vZY
+ioP
+lYg
+lYg
+nsX
+lYg
+lYg
 gTH
 gTH
 gTH
@@ -468720,27 +469894,27 @@ ogs
 (146,1,4) = {"
 gBM
 gBM
-fwS
+vZY
 mCg
-lSw
+mqa
 ngu
 bcM
-lSw
-lSw
-lSw
-lSw
-lSw
-lSw
-lSw
-lSw
-lSw
-fwS
-gTH
-dCq
-dCq
-dCq
-dCq
-gTH
+mqa
+mqa
+lXQ
+mqa
+mqa
+mqa
+mqa
+mqa
+qte
+vZY
+nsX
+lYg
+lYg
+lYg
+lYg
+nsX
 gTH
 gTH
 gTH
@@ -469172,27 +470346,27 @@ ogs
 (147,1,4) = {"
 gBM
 gBM
-fwS
-fwS
-fwS
-fwS
-fwS
-lSw
-lSw
-lSw
-lSw
-lSw
-lSw
-lSw
-lSw
-lSw
-fwS
-gTH
-dCq
-gTH
-gTH
-dCq
-gTH
+vZY
+vZY
+vZY
+vZY
+vZY
+mqa
+mqa
+rTt
+mqa
+mqa
+rTt
+mqa
+mqa
+mqa
+vZY
+nsX
+lYg
+nsX
+nsX
+lYg
+nsX
 gTH
 gTH
 gTH
@@ -469624,27 +470798,27 @@ ogs
 (148,1,4) = {"
 gBM
 gBM
-fwS
-lSw
-lSw
-lSw
+vZY
+ezV
+mqa
+mqa
 pGG
-lSw
-fwS
-fwS
-fwS
-fwS
-fwS
-fwS
-lSw
-lSw
-fwS
-gTH
-dCq
-gTH
-dCq
-dCq
-gTH
+mqa
+vZY
+vZY
+vZY
+vZY
+vZY
+vZY
+mqa
+mqa
+vZY
+nsX
+lYg
+nsX
+oFV
+lYg
+nsX
 gTH
 gTH
 gTH
@@ -470076,27 +471250,27 @@ ogs
 (149,1,4) = {"
 gBM
 gBM
-fwS
+vZY
 dgd
-lSw
-lSw
-fwS
-fwS
-fwS
+mqa
+nBH
+vZY
+vZY
+vZY
 eNd
-uVt
-jVb
+miT
+qKL
 qUh
-fwS
-lSw
-lSw
-fwS
-gTH
-ubW
-dCq
-dCq
-dCq
-dCq
+vZY
+mqa
+qte
+vZY
+nsX
+lYg
+lYg
+rUT
+lYg
+oFV
 gTH
 gTH
 fwS
@@ -470528,28 +471702,28 @@ ogs
 (150,1,4) = {"
 gBM
 gBM
-fwS
-vGh
+vZY
+ses
 iTB
 yaC
-fwS
+vZY
 iJM
-uVt
-uVt
+gLN
+iei
 nzP
-fwS
-uVt
-fwS
-lSw
-lSw
-fwS
-fwS
-fwS
-dCq
-dCq
-dCq
-dCq
-fwS
+vZY
+miT
+vZY
+oKT
+kFB
+vZY
+vZY
+vZY
+lYg
+lYg
+lYg
+lYg
+vZY
 gTH
 vMR
 vMR
@@ -470980,28 +472154,28 @@ cxA
 (151,1,4) = {"
 gBM
 gBM
-fwS
-fwS
-fwS
-fwS
-fwS
-uVt
+vZY
+vZY
+vZY
+vZY
+vZY
+qGD
 uVt
 uVt
 uVt
 qGD
-uVt
+iei
 oVo
-lSw
-ebC
+mqa
+fWH
 vEG
-dCq
-dCq
-dCq
-dCq
-dCq
-dCq
-fwS
+lYg
+lYg
+lYg
+lYg
+lYg
+lYg
+vZY
 vMR
 vMR
 vMR
@@ -471436,23 +472610,23 @@ gTH
 gTH
 qRS
 rCo
-fwS
+vZY
 hkO
 uVt
 bib
 ijH
-uVt
-uVt
+gLN
+gLN
 cvH
-ebC
-ebC
-dCq
-dCq
-ebC
-dCq
-dCq
+fWH
+fWH
+plf
+lYg
+fWH
+lYg
+lYg
 eQQ
-ebC
+fWH
 sVG
 vMR
 vMR
@@ -471894,18 +473068,18 @@ uVt
 uVt
 uVt
 qGD
-uVt
+iei
 cvH
-lSw
+mqa
 pqX
-fwS
-dCq
-dCq
-dCq
-dCq
-ebC
-ebC
-fwS
+vZY
+lYg
+lYg
+lYg
+lYg
+fWH
+tav
+vZY
 vMR
 vMR
 vMR
@@ -472340,24 +473514,24 @@ gTH
 dCq
 dCq
 uFa
-fwS
-fwS
+vZY
+vZY
 aAn
-uVt
-uVt
-fwS
-uVt
-fwS
-lSw
-ebC
-fwS
-gTH
-dCq
-dCq
-dCq
-ebC
-fwS
-fwS
+gLN
+iei
+vZY
+miT
+vZY
+oKT
+hWC
+vZY
+nsX
+lYg
+oFV
+lYg
+jff
+vZY
+vZY
 vMR
 vMR
 vMR
@@ -472793,22 +473967,22 @@ vMR
 vMR
 pTA
 rCo
-fwS
-fwS
+vZY
+vZY
 jVb
-uVt
+gLN
 qqz
 wCy
-fwS
-ebC
-ebC
-fwS
-gTH
-gTH
-gTH
-dCq
-dCq
-fwS
+vZY
+fWH
+fWH
+vZY
+nsX
+nsX
+nsX
+lYg
+lYg
+vZY
 vMR
 vMR
 vMR
@@ -473246,13 +474420,13 @@ vMR
 vMR
 pTA
 rCo
-fwS
-fwS
+vZY
+vZY
 rjm
-fwS
-fwS
-fwS
-lSw
+vZY
+vZY
+vZY
+mqa
 pqX
 gTH
 gTH
@@ -473702,8 +474876,8 @@ qRS
 qRS
 iVB
 qRS
-gTH
-fwS
+nsX
+vZY
 cvH
 gTH
 gTH
@@ -474152,7 +475326,7 @@ vMR
 vMR
 vMR
 dCq
-dCq
+wJW
 dCq
 gTH
 fwS
@@ -475058,8 +476232,8 @@ vMR
 vMR
 dCq
 dCq
-dCq
-dCq
+mUC
+wJW
 gTH
 gTH
 gTH

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -588,6 +588,9 @@
 "alR" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -654,6 +657,15 @@
 	dir = 8
 	},
 /area/rogue/under/town/basement)
+"anI" = (
+/obj/structure/rogue/trophy/deer,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "anL" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
@@ -752,6 +764,9 @@
 /area/rogue/indoors/town)
 "apz" = (
 /obj/structure/fluff/statue/gargoyle/moss,
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "apQ" = (
@@ -1418,6 +1433,9 @@
 /area/rogue/outdoors/mountains)
 "aDE" = (
 /obj/machinery/light/rogue/oven/west,
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -1686,6 +1704,7 @@
 	pixel_x = -10;
 	pixel_y = 6
 	},
+/obj/structure/fluff/wallclock/directional/west,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
@@ -2594,6 +2613,13 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"bcv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bcx" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/rtfield)
@@ -2786,6 +2812,15 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"bhc" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bhg" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grassred,
@@ -3535,6 +3570,14 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"byh" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "byA" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/rogue/church,
@@ -3827,6 +3870,9 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "bDK" = (
@@ -4028,6 +4074,9 @@
 "bHI" = (
 /obj/machinery/light/rogue/torchholder/directional/east,
 /obj/item/cooking/platter,
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
@@ -4138,6 +4187,10 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "bJF" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	pixel_y = 1
+	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "bJM" = (
@@ -4433,6 +4486,17 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/south,
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/indoors/town/church/chapel)
+"bPB" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 1
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bPD" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/blocks{
@@ -4464,6 +4528,12 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
+"bQi" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "bQD" = (
 /obj/item/rogueweapon/whip,
 /turf/closed/wall/mineral/rogue/pipe{
@@ -5058,6 +5128,9 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -5154,6 +5227,19 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
+"cfv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
+"cfC" = (
+/obj/structure/telescope,
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "cfI" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble,
@@ -5208,8 +5294,12 @@
 /area/rogue/indoors)
 "cgN" = (
 /obj/item/reagent_containers/glass/mortar,
-/obj/structure/fluff/walldeco/customflag{
+/obj/structure/fluff/walldeco/wallshield{
 	pixel_y = 32
+	},
+/obj/item/alch/ozium,
+/obj/effect/decal/cobble/mossy{
+	dir = 6
 	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
@@ -5928,9 +6018,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "cxf" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/fluff/walldeco/wallshield{
+	pixel_x = -32
+	},
 /turf/open/floor/rogue/blocks{
-	dir = 4
+	dir = 1
 	},
 /area/rogue/under/cave/dungeon/fort_dusk)
 "cxi" = (
@@ -7692,6 +7784,9 @@
 /area/rogue/under/town/basement/keep)
 "dkw" = (
 /obj/structure/fermenting_barrel/water,
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "dkC" = (
@@ -7937,6 +8032,7 @@
 /obj/machinery/light/rogue/torchholder/directional/north,
 /obj/structure/fluff/alch,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/effect/decal/cobble/mossy,
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -8157,6 +8253,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"dus" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "duu" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -8194,6 +8299,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"duN" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_x = -31;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "duT" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -8241,6 +8353,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
 	},
+/obj/item/roguebin,
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -8330,6 +8443,14 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"dyo" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dyv" = (
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -8436,6 +8557,7 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
 /obj/effect/decal/remains/human,
+/obj/item/bouquet/rosa,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "dBb" = (
@@ -8871,6 +8993,14 @@
 /obj/structure/fermenting_barrel/crafted,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"dJU" = (
+/obj/structure/fluff/walldeco/wallshield{
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dJZ" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/naturalstone,
@@ -9221,6 +9351,14 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"dRM" = (
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "dSa" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -9346,6 +9484,10 @@
 "dUL" = (
 /obj/machinery/light/rogue/torchholder/directional/south,
 /obj/structure/table/wood,
+/obj/item/reagent_containers/glass/alchemical{
+	pixel_x = -8;
+	pixel_y = 8
+	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "dUR" = (
@@ -10120,8 +10262,10 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/town/basement/keep)
 "ekP" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/statue/knightalt,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
 /area/rogue/under/cave/dungeon/fort_dusk)
 "ekT" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
@@ -11082,6 +11226,12 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
+"eCN" = (
+/obj/item/needle/thorn,
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eCQ" = (
 /obj/structure/stairs{
 	dir = 4
@@ -11129,6 +11279,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"eDC" = (
+/obj/effect/decal/cobble/mossy,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "eDO" = (
 /obj/machinery/light/rogue/torchholder/directional/north,
 /turf/open/floor/rogue/blocks,
@@ -12775,6 +12931,12 @@
 "fkB" = (
 /turf/open/lava,
 /area/rogue/outdoors/mountains/decap)
+"fkK" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fkL" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/priest{
@@ -12863,7 +13025,7 @@
 "fms" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
-/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -13802,6 +13964,13 @@
 "fIs" = (
 /obj/structure/table/wood,
 /obj/item/cooking/platter,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -13885,6 +14054,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
+"fKb" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "fKc" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/dirt/road,
@@ -14732,6 +14907,10 @@
 /obj/item/rogueweapon/eaglebeak/lucerne,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"gbK" = (
+/obj/structure/fluff/wallclock/directional/south,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "gbU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -14942,6 +15121,10 @@
 /obj/structure/table/wood{
 	icon_state = "map5"
 	},
+/obj/structure/globe{
+	pixel_x = -10;
+	pixel_y = 0
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "ggS" = (
@@ -15074,6 +15257,9 @@
 /area/rogue/under/cave/dungeon/fort_dusk)
 "gjF" = (
 /obj/machinery/light/rogue/torchholder/directional/east,
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -15457,6 +15643,9 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "gte" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -16025,6 +16214,7 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
@@ -16683,6 +16873,9 @@
 /area/rogue/indoors/town)
 "gTx" = (
 /obj/machinery/light/rogue/torchholder/directional/south,
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "gTA" = (
@@ -17593,6 +17786,7 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/machinery/light/rogue/wallfire/candle/weak/directional/north,
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "hkR" = (
@@ -17647,6 +17841,7 @@
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
 "hmm" = (
 /obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks{
 	dir = 4
 	},
@@ -18426,6 +18621,9 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = -32
 	},
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "hBO" = (
@@ -18634,9 +18832,7 @@
 "hFO" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "hFS" = (
 /obj/item/bedsheet/rogue/fabric,
@@ -19914,6 +20110,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"igP" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/wolf,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/cave)
 "igX" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
@@ -19990,6 +20190,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"iiJ" = (
+/obj/structure/flora/roguegrass/bush,
+/obj/machinery/light/rogue/wallfire/candle/weak/directional/west,
+/turf/open/floor/rogue/grassred,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iiL" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -20124,6 +20329,14 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/old_ruin)
+"ila" = (
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ilg" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -20298,6 +20511,9 @@
 /area/rogue/under/cave/dungeon/winding_halls)
 "ioM" = (
 /obj/item/storage/belt/rogue/pouch/coins/poor,
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "ipd" = (
@@ -20948,6 +21164,13 @@
 /obj/structure/roguemachine/scomm/directional/north,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"iBL" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iBM" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -21436,6 +21659,14 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/dungeon/winding_halls)
+"iMv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "iMB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -22241,6 +22472,10 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"jbt" = (
+/obj/structure/fluff/wallclock/directional/east,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jbE" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/north,
 /obj/structure/fermenting_barrel/water,
@@ -22256,6 +22491,17 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
+"jbU" = (
+/obj/structure/mineral_door/wood/violet{
+	locked = 1
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jcb" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -22446,6 +22692,12 @@
 	},
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
+"jfL" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jfM" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -22476,7 +22728,14 @@
 	dir = 8;
 	icon_state = "longtable"
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+/obj/item/reagent_containers/glass/bottle/rogue/stampot{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/rogue/instrument/hurdygurdy{
+	pixel_x = 6;
+	pixel_y = -4
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -22542,7 +22801,19 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"jhw" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jhC" = (
+/obj/item/roguestatue/iron{
+	pixel_x = 6;
+	pixel_y = -3
+	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "jhF" = (
@@ -22676,6 +22947,14 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"jkk" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jkn" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -23474,6 +23753,9 @@
 "jCG" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "jCN" = (
@@ -24434,6 +24716,9 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/ranged,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/old_ruin)
+"jYx" = (
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "jYI" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -24555,6 +24840,12 @@
 /obj/item/flint,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"kaU" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kaY" = (
 /obj/structure/bars/tough,
 /turf/open/floor/rogue/cobble,
@@ -24614,6 +24905,15 @@
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
+"kde" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kdg" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /turf/open/floor/rogue/blocks,
@@ -26110,6 +26410,17 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"kJZ" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kKt" = (
 /obj/structure/bars,
 /turf/open/water/swamp/deep,
@@ -26406,6 +26717,10 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"kPV" = (
+/obj/effect/decal/cobbleedge,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "kPX" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
@@ -26431,6 +26746,7 @@
 "kQp" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/item/flint,
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -26592,6 +26908,8 @@
 /area/rogue/under/town/basement/keep)
 "kTq" = (
 /obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
+/obj/item/burial_shroud,
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -26925,6 +27243,9 @@
 	pixel_x = -6;
 	pixel_y = 15
 	},
+/obj/effect/decal/cobbleedge{
+	dir = 5
+	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "laP" = (
@@ -27099,6 +27420,10 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"leI" = (
+/obj/item/needle/thorn,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "leS" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -27219,6 +27544,12 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
+"lgK" = (
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "lgL" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -28678,6 +29009,9 @@
 	pixel_x = 2;
 	pixel_y = 19
 	},
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
@@ -29134,6 +29468,9 @@
 /area/rogue/indoors/shelter/mountains)
 "lVn" = (
 /obj/structure/fermenting_barrel,
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -30203,6 +30540,15 @@
 /obj/machinery/light/rogue/wallfire/candle/directional/south,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
+"mtH" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mtJ" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/woodturned,
@@ -30358,6 +30704,10 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"mxr" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/cave)
 "mxx" = (
 /obj/effect/decal/herringbone,
 /turf/open/floor/rogue/cobble/mossy,
@@ -30635,6 +30985,15 @@
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/old_ruin)
+"mDv" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/structure/fluff/wallclock/directional/east,
+/obj/item/burial_shroud,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "mDy" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 1;
@@ -31959,6 +32318,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/dungeon/winding_halls)
+"neI" = (
+/obj/item/needle/thorn,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "neM" = (
 /obj/structure/mineral_door/wood/red,
 /turf/open/floor/rogue/cobble,
@@ -32243,12 +32608,27 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
+"nkd" = (
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nkf" = (
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/dungeon/winding_halls)
+"nko" = (
+/obj/structure/fluff/walldeco/painting{
+	pixel_y = 32
+	},
+/obj/effect/decal/cobble/mossy,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nkt" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt/road,
@@ -32322,6 +32702,13 @@
 "nlW" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town)
+"nlZ" = (
+/obj/item/natural/rock,
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nmh" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/blocks/green,
@@ -32473,6 +32860,9 @@
 /area/rogue/under/cave/dungeon/winding_halls)
 "noj" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -33049,6 +33439,13 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/cave/dungeon/fort_dusk)
+"nzU" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nzW" = (
 /obj/structure/chair/bench/church/smallbench{
 	dir = 1
@@ -33495,6 +33892,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
+"nIK" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nJa" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/naturalstone,
@@ -33699,6 +34105,10 @@
 	},
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -7;
+	pixel_y = 8
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -34200,6 +34610,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains)
+"nYm" = (
+/obj/item/natural/rock/gold,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "nYs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -34978,6 +35392,15 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"oqN" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "oqR" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/rogue/blocks,
@@ -35177,6 +35600,7 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /obj/effect/decal/remains/human,
+/obj/item/quiver/arrows,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "ouE" = (
@@ -35191,6 +35615,10 @@
 /obj/item/storage/belt/rogue/pouch/coins/poor,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"ouV" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ove" = (
 /obj/structure/stairs{
 	dir = 1
@@ -35946,6 +36374,9 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "oKD" = (
 /obj/structure/mineral_door/wood/violet,
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -37015,6 +37446,12 @@
 "phl" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town)
+"phy" = (
+/obj/structure/fluff/walldeco/bigpainting{
+	pixel_x = 0
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "phz" = (
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/floor/rogue/cobble,
@@ -38159,6 +38596,9 @@
 /obj/structure/closet/crate/chest/neu,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /obj/item/reagent_containers/glass/bottle/rogue/strongpoison,
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "pFq" = (
@@ -38561,6 +39001,13 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
+/obj/item/natural/cloth{
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "pOh" = (
@@ -38959,6 +39406,9 @@
 "pWk" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/decal/cobbleedge{
+	dir = 5
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -39192,6 +39642,14 @@
 	dir = 4
 	},
 /area/rogue/outdoors/beach/forest)
+"qdy" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qdC" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/west,
 /turf/open/floor/rogue/cobble,
@@ -39374,6 +39832,7 @@
 /obj/structure/stairs/stone{
 	dir = 4
 	},
+/obj/structure/fluff/walldeco/bigpainting/lake,
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
@@ -39815,6 +40274,7 @@
 /obj/structure/stone_tile/slab/cracked{
 	dir = 10
 	},
+/obj/machinery/light/rogue/wallfire/candle/weak/directional/east,
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "qqD" = (
@@ -39904,6 +40364,14 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/vulnafir)
+"qsr" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qsu" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble/mossy,
@@ -40400,6 +40868,15 @@
 /obj/structure/chair/arrestchair,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/beach/forest)
+"qDi" = (
+/obj/item/roguestatue/silver{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/concrete{
+	dir = 1
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qDu" = (
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/under/town/sewer)
@@ -40735,6 +41212,10 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane/inner)
+"qIo" = (
+/obj/machinery/light/rogue/wallfire/candle/directional/north,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qIp" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassred,
@@ -40756,6 +41237,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
+"qIP" = (
+/obj/item/natural/bone,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qJj" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
@@ -40979,6 +41464,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"qNL" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qNM" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/town/sewer)
@@ -41122,6 +41613,9 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "qRd" = (
 /obj/item/chair/rogue/crafted,
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -41293,6 +41787,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"qVL" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qVM" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -41309,6 +41807,18 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/tavern)
+"qWt" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/reagent_containers/glass/cup{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/glass/cup{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "qWH" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -42220,6 +42730,15 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"rpc" = (
+/obj/item/storage/roguebag,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rpl" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/wood,
@@ -42351,6 +42870,9 @@
 "rri" = (
 /obj/structure/fluff/statue/knight/interior,
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "rrl" = (
@@ -42770,6 +43292,14 @@
 	dir = 8
 	},
 /area/rogue/under/cave/dungeon/fort_dusk)
+"rAl" = (
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rAy" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 1
@@ -42873,6 +43403,12 @@
 "rCV" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"rCX" = (
+/obj/item/pestle,
+/turf/open/floor/rogue/blocks{
+	dir = 1
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rCY" = (
 /obj/item/fishingrod,
 /turf/open/floor/rogue/twig,
@@ -43234,6 +43770,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"rJq" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rJt" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -43371,6 +43913,12 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"rMB" = (
+/obj/item/roguestatue/steel,
+/turf/open/floor/rogue/concrete{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rMI" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -43509,6 +44057,12 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
+"rPD" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "rPF" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/concrete,
@@ -43997,6 +44551,10 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dungeon/dragonden)
+"sby" = (
+/obj/machinery/light/rogue/wallfire/candle/directional/east,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sbK" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -44368,6 +44926,13 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"sjz" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/clock,
+/turf/open/floor/rogue/wood,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sjG" = (
 /obj/structure/winch{
 	dir = 8;
@@ -44695,6 +45260,12 @@
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"sor" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "soR" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -45058,6 +45629,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach)
+"swX" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sxj" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/north,
 /obj/structure/fluff/railing/border{
@@ -45096,6 +45675,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"syd" = (
+/obj/effect/decal/cobble/mossy,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "syj" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/cobblerock,
@@ -45209,6 +45792,9 @@
 "sAi" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "sAq" = (
@@ -45968,6 +46554,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/church/chapel)
+"sSW" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sTa" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/cobble,
@@ -45983,6 +46575,15 @@
 /obj/item/rogueweapon/whip,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"sTt" = (
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sTu" = (
 /obj/machinery/light/rogue/torchholder/directional/east,
 /turf/open/water/bath,
@@ -46089,6 +46690,12 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
+"sVS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "sWn" = (
 /obj/machinery/light/rogue/torchholder/directional/east,
 /obj/structure/flora/ausbushes/brflowers,
@@ -46713,6 +47320,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"tkC" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tkH" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
@@ -46976,6 +47593,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"tqY" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/item/burial_shroud,
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "tra" = (
 /obj/structure/stairs{
 	dir = 1
@@ -47419,6 +48044,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/structure/fluff/walldeco/wallshield{
+	pixel_x = -32
+	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -48073,6 +48701,9 @@
 /obj/item/reagent_containers/glass/bucket/pot{
 	pixel_x = 1;
 	pixel_y = 8
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 1
 	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
@@ -49887,6 +50518,13 @@
 	},
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave)
+"uBL" = (
+/obj/item/roguestatue/iron{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uBN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/directional/south,
 /obj/structure/table/wood{
@@ -50845,6 +51483,14 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/cave/dungeon/fort_dusk)
+"uVB" = (
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "uVN" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -50883,6 +51529,7 @@
 /area/rogue/under/town/basement/keep)
 "uWJ" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
+/obj/item/rope,
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -51067,6 +51714,10 @@
 /area/rogue/indoors/shelter/woods)
 "vab" = (
 /obj/machinery/light/rogue/torchholder/directional/west,
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
 /turf/open/floor/rogue/blocks/green{
 	dir = 8
 	},
@@ -51142,6 +51793,7 @@
 /area/rogue/under/cave/dungeon/goblinfort)
 "vbj" = (
 /obj/structure/rack/rogue/shelf/biggest,
+/obj/item/storage/keyring,
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -51721,6 +52373,9 @@
 /obj/structure/mineral_door/wood/violet{
 	locked = 1
 	},
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "vnW" = (
@@ -52004,6 +52659,12 @@
 /obj/effect/decal/remains/cow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"vuY" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vuZ" = (
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/twig,
@@ -52303,6 +52964,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
+"vBz" = (
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 1
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vBG" = (
 /obj/machinery/light/rogue/wallfire/candle/directional/east,
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
@@ -52521,7 +53190,16 @@
 "vGh" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/machinery/light/rogue/wallfire/candle/directional/north,
 /turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
+"vGo" = (
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks{
 	dir = 8
 	},
 /area/rogue/under/cave/dungeon/fort_dusk)
@@ -52566,9 +53244,7 @@
 "vHl" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/blocks{
-	dir = 8
-	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "vHm" = (
 /obj/machinery/light/rogue/hearth,
@@ -53141,6 +53817,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"vTa" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "vTb" = (
 /obj/structure/mirror,
 /turf/open/floor/rogue/carpet,
@@ -53210,8 +53894,12 @@
 	icon_state = "map2"
 	},
 /obj/item/reagent_containers/glass/cup/golden/poison{
-	pixel_x = 4;
-	pixel_y = 12
+	pixel_x = 12;
+	pixel_y = 16
+	},
+/obj/item/ramrod{
+	pixel_x = -7;
+	pixel_y = 8
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cave/dungeon/fort_dusk)
@@ -53883,7 +54571,7 @@
 /area/rogue/indoors/town/manor)
 "wjI" = (
 /obj/structure/closet/crate/coffin,
-/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/blocks{
 	dir = 8
 	},
@@ -56225,6 +56913,11 @@
 /obj/structure/brewers_press,
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/town/basement)
+"xmM" = (
+/turf/open/floor/rogue/blocks{
+	dir = 1
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "xmO" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
@@ -56444,8 +57137,11 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "xqz" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/obj/structure/fluff/walldeco/customflag{
+/obj/structure/fluff/walldeco/wallshield{
 	pixel_y = 32
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 10
 	},
 /turf/open/floor/rogue/blocks{
 	dir = 8
@@ -58110,6 +58806,13 @@
 /obj/item/reagent_containers/glass/cup/golden/poison,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dungeon/vulnafir)
+"ydH" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave/dungeon/fort_dusk)
 "ydI" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -58190,6 +58893,26 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
+"yeK" = (
+/obj/machinery/light/rogue/torchholder/directional/north,
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks/green{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
+"yeP" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "yeR" = (
 /obj/effect/decal/herringbone{
 	dir = 9
@@ -58332,6 +59055,15 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town)
+"yhk" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks{
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon/fort_dusk)
 "yhv" = (
 /obj/item/roguecoin/copper/pile,
 /obj/structure/closet/crate/chest,
@@ -58582,6 +59314,7 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mole{
 	faction = list("wolfs","undead")
 	},
+/obj/structure/fluff/nest,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon/fort_dusk)
 "ymd" = (
@@ -118715,7 +119448,7 @@ sVG
 fRi
 jhC
 lRU
-nwV
+qDi
 oDz
 sVG
 fnC
@@ -119620,7 +120353,7 @@ eKt
 nwV
 fOk
 oVu
-upV
+rMB
 sVG
 fnC
 fnC
@@ -347430,8 +348163,8 @@ tsB
 tsB
 rjm
 dkw
-qoE
-qoE
+rPD
+nlZ
 qoE
 ylK
 vbj
@@ -347882,7 +348615,7 @@ tsB
 tsB
 rjm
 qoE
-qoE
+qIP
 hkI
 qoE
 bvY
@@ -348344,7 +349077,7 @@ sVG
 sVG
 jYO
 pFp
-nnU
+sSW
 rri
 sVG
 tsB
@@ -348362,8 +349095,8 @@ tsB
 tsB
 hxw
 fnC
-fnC
-fnC
+sqN
+tIH
 tsB
 tsB
 tsB
@@ -348785,19 +349518,19 @@ sVG
 sVG
 sVG
 sVG
+ekP
 bvY
-bvY
-bvY
+xmM
 rzW
-qoE
+leI
 bvY
 ndN
 sVG
 sVG
-nnU
+vuY
 nnU
 kFd
-nnU
+rJq
 sVG
 sVG
 tsB
@@ -348807,7 +349540,7 @@ tsB
 tsB
 tsB
 tsB
-hxw
+igP
 fnC
 fnC
 fnC
@@ -349238,12 +349971,12 @@ snX
 sVG
 sVG
 noj
-bvY
-bvY
+jhw
+byh
 qoE
-bvY
-bvY
-bvY
+vTa
+jhw
+byh
 sDF
 nnU
 nRS
@@ -349263,8 +349996,8 @@ fnC
 fnC
 fnC
 fnC
-fnC
-fnC
+tIH
+tIH
 fnC
 fnC
 fnC
@@ -349690,10 +350423,10 @@ xlZ
 xyl
 sVG
 sVG
-sDF
+jbU
 sVG
 sVG
-qoE
+bQi
 sVG
 sVG
 sVG
@@ -349701,7 +350434,7 @@ pnI
 bWj
 ggA
 vUY
-ekP
+nnU
 gTx
 sVG
 tsB
@@ -349720,7 +350453,7 @@ tsB
 tsB
 tsB
 fnC
-fnC
+tIH
 tsB
 tsB
 tsB
@@ -350137,15 +350870,15 @@ ogs
 qmf
 tsB
 sVG
-bvY
-bvY
+anI
+iMv
 bvY
 sVG
-bvY
+byh
 bvY
 sVG
 dAM
-qoE
+qIP
 sVG
 sVG
 pNY
@@ -350590,21 +351323,21 @@ qmf
 tsB
 sVG
 hFO
-bvY
-bvY
+dRM
+xmM
 oKD
-bvY
+eDC
 bvY
 sVG
 ouC
 qoE
 sVG
 gfT
+kPV
 nnU
 nnU
 nnU
-nnU
-nnU
+xmM
 nnU
 nnU
 nnU
@@ -350612,11 +351345,11 @@ vWe
 fnC
 fnC
 tsB
+mxr
 fnC
 fnC
 fnC
-fnC
-fnC
+sqN
 tsB
 tsB
 qPv
@@ -351045,18 +351778,18 @@ vHl
 gte
 bvY
 sVG
+qsr
 bvY
-qYJ
 sVG
 uhi
 ylK
 sVG
 gfT
-nnU
+kPV
 nnU
 jCG
-nnU
-nnU
+qNL
+qNL
 sAi
 nnU
 vbS
@@ -351501,7 +352234,7 @@ pBW
 bvY
 sVG
 mwM
-qoE
+uBL
 sVG
 sVG
 ccr
@@ -352397,19 +353130,19 @@ ogs
 qmf
 tsB
 sVG
-kTq
+tqY
 wjI
 kTq
 eUs
 bvY
 bvY
 bvY
+cxf
+vBz
+ila
+rpc
 bvY
-bvY
-bvY
-bvY
-bvY
-nnU
+gbK
 sVG
 kDl
 bPD
@@ -352850,24 +353583,24 @@ qmf
 tsB
 sVG
 xqz
-bvY
-bvY
-bvY
-bvY
-bvY
+neI
+rCX
+vGo
+swX
+iMv
 lmn
-bvY
+vTa
 gjF
-bvY
-lmn
-bvY
-nnU
+byh
+bPB
+mtH
+iBL
 sVG
 qpN
 bvY
 qRd
-bvY
-nnU
+jhw
+jfL
 sVG
 sVG
 sVG
@@ -353305,8 +354038,8 @@ dqw
 bvY
 ulV
 pWk
-bvY
-bvY
+qdy
+uVB
 sVG
 xLf
 sVG
@@ -353319,7 +354052,7 @@ niH
 bvY
 tPQ
 fIs
-nnU
+syd
 lbV
 vHQ
 lbV
@@ -353770,11 +354503,11 @@ sVG
 nNV
 bvY
 aDE
-bvY
-nnU
+dyo
+fkK
 lbV
 mFj
-cxf
+lbV
 hmm
 qPv
 qPv
@@ -354206,8 +354939,8 @@ qmf
 tsB
 sVG
 fms
-kTq
-kTq
+mDv
+wjI
 xKf
 bvY
 qYJ
@@ -354661,17 +355394,17 @@ sVG
 sVG
 sVG
 sVG
-ccr
+yeP
 bvY
 sVG
 lVn
-bPD
+nIK
 tBP
 jfS
 qVM
 bvY
-bvY
-bvY
+xmM
+dJU
 bvY
 bvY
 bvY
@@ -355113,7 +355846,7 @@ tsB
 tsB
 tsB
 sVG
-bvY
+nko
 bvY
 sDF
 bvY
@@ -355122,9 +355855,9 @@ bvY
 bvY
 bvY
 bvY
-xKf
-bvY
-xKf
+bhc
+jhw
+yhk
 bvY
 bvY
 nnU
@@ -356023,7 +356756,7 @@ sVG
 kYG
 orX
 vuG
-orX
+oqN
 alR
 sVG
 tsB
@@ -356482,11 +357215,11 @@ tsB
 fnC
 tsB
 tsB
-sJx
-sJx
-sJx
-sJx
-sJx
+qPv
+qPv
+qPv
+qPv
+qPv
 dCq
 dCq
 dCq
@@ -357384,7 +358117,7 @@ tsB
 tsB
 tsB
 tsB
-fnC
+tIH
 qPv
 qPv
 qPv
@@ -358285,10 +359018,10 @@ tsB
 tsB
 qPv
 qPv
+sqN
 fnC
 fnC
-fnC
-fnC
+tIH
 qPv
 qPv
 qPv
@@ -358737,7 +359470,7 @@ qPv
 qPv
 qPv
 qPv
-fnC
+tIH
 fnC
 qPv
 qPv
@@ -359640,7 +360373,7 @@ qPv
 qPv
 qPv
 qPv
-fnC
+tIH
 fnC
 qPv
 qPv
@@ -462699,7 +463432,7 @@ gTH
 nsX
 nsX
 slv
-sfi
+qWt
 qeo
 nsX
 nsX
@@ -463607,7 +464340,7 @@ sCn
 sCn
 sCn
 sCn
-wks
+sjz
 ylu
 nsX
 gTH
@@ -464050,7 +464783,7 @@ sVG
 uLr
 nsX
 nsX
-qoE
+qIP
 qoE
 qoE
 qoE
@@ -464498,7 +465231,7 @@ qoE
 oLj
 sVG
 teD
-sfi
+bcv
 goQ
 sfi
 qoE
@@ -464949,10 +465682,10 @@ nsX
 qoE
 nsX
 nsX
-sfi
-sfi
+cfv
+jYx
 bJF
-sfi
+kaU
 qoE
 nsX
 nsX
@@ -465401,16 +466134,16 @@ gjs
 qoE
 nsX
 sVG
-sfi
+kde
 sVG
-sfi
-sfi
-sVG
-sVG
+jYx
+lgK
 sVG
 sVG
 sVG
-hhB
+sVG
+sVG
+nzU
 sCn
 sCn
 sCn
@@ -465853,10 +466586,10 @@ nsX
 ltM
 nsX
 sVG
-rzm
+phy
 laN
-sfi
-sfi
+sVS
+nkd
 sfi
 sfi
 gfT
@@ -465869,8 +466602,8 @@ sCn
 sCn
 wks
 sfi
-sfi
 lCs
+bcv
 sfi
 sfi
 tFr
@@ -466320,11 +467053,11 @@ sCn
 sCn
 sCn
 wks
-sfi
-sfi
-sfi
-sfi
-sfi
+cfv
+sor
+jYx
+ydH
+kaU
 sVG
 gTH
 gTH
@@ -466760,7 +467493,7 @@ sVG
 rzm
 sVG
 uLr
-sfi
+cfv
 sVG
 sVG
 sVG
@@ -466772,7 +467505,7 @@ wYa
 wYa
 wYa
 ouk
-sfi
+fKb
 sVG
 nsX
 nsX
@@ -467211,8 +467944,8 @@ nsX
 sVG
 sfi
 sfi
-sfi
-sfi
+cfv
+jYx
 sVG
 nsX
 nsX
@@ -467222,9 +467955,9 @@ sfi
 sfi
 sfi
 sfi
-sfi
-sfi
-naD
+jbt
+sby
+tkC
 sVG
 gTH
 gTH
@@ -467669,7 +468402,7 @@ sVG
 nsX
 nsX
 nsX
-sfi
+qVL
 cro
 nsX
 nsX
@@ -468565,7 +469298,7 @@ sVG
 bUj
 nPZ
 rva
-qGD
+eCN
 bWg
 rga
 qGD
@@ -468580,7 +469313,7 @@ nsX
 cLb
 nsX
 nsX
-pVl
+qoE
 qoE
 gTH
 gTH
@@ -469029,7 +469762,7 @@ qgT
 mec
 sVG
 qoE
-qoE
+qIP
 nsX
 nsX
 nsX
@@ -469482,7 +470215,7 @@ qGD
 sVG
 cLb
 qoE
-qoE
+nYm
 nsX
 qoE
 qoE
@@ -469925,12 +470658,12 @@ bcM
 qGD
 qGD
 vab
+jYx
+duN
+rAl
 qGD
 qGD
-qGD
-qGD
-qGD
-tLm
+kJZ
 sVG
 nsX
 qoE
@@ -470377,12 +471110,12 @@ sVG
 qGD
 qGD
 xoz
-qGD
-qGD
+dus
+dus
 xoz
 qGD
 qGD
-qGD
+jkk
 sVG
 nsX
 qoE
@@ -470834,7 +471567,7 @@ sVG
 sVG
 sVG
 qGD
-qGD
+sTt
 sVG
 nsX
 qoE
@@ -471281,7 +472014,7 @@ sVG
 sVG
 sVG
 eNd
-qCM
+iiJ
 fBd
 qUh
 sVG
@@ -471742,10 +472475,10 @@ ihR
 sVG
 sVG
 sVG
+qIo
 qoE
 qoE
-qoE
-qoE
+ouV
 sVG
 gTH
 vMR
@@ -472197,7 +472930,7 @@ qoE
 qoE
 qoE
 qoE
-qoE
+sfi
 sVG
 vMR
 vMR
@@ -472649,7 +473382,7 @@ sfi
 qoE
 qoE
 eQQ
-sfi
+cfC
 vZY
 vMR
 vMR
@@ -473099,7 +473832,7 @@ sVG
 qoE
 qoE
 qoE
-qoE
+qIP
 sfi
 ioM
 sVG
@@ -473545,7 +474278,7 @@ bSp
 sVG
 qCM
 sVG
-mhU
+yeK
 naD
 sVG
 nsX
@@ -473997,7 +474730,7 @@ sqF
 qqz
 wCy
 sVG
-sfi
+jYx
 sfi
 sVG
 nsX
@@ -474449,7 +475182,7 @@ lNG
 sVG
 sVG
 sVG
-qGD
+dus
 pqX
 gTH
 gTH
@@ -475801,7 +476534,7 @@ vMR
 vMR
 vMR
 dCq
-dCq
+dNF
 qOV
 dCq
 lSw

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -604,6 +604,16 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	converted_type = /area/rogue/outdoors/dungeon1
 	brief_descriptor = "in old sunmarch, cast beneath the mountains of scordris"
 
+/area/rogue/under/cave/dungeon/fort_dusk
+	name = "The Forsaken Bastille"
+	icon_state = "duke"
+	first_time_text = "THE FORSAKEN BASTILLE"
+	droning_sound = 'sound/music/area/dungeon2.ogg'
+	droning_sound_dusk = null
+	droning_sound_night = null
+	converted_type = /area/rogue/outdoors/dungeon1
+	brief_descriptor = "in old sunmarch, where only the 'gulls remain to cry out"
+
 //////
 /////
 ////     TOWN AREAS


### PR DESCRIPTION
## About The Pull Request

Adds a new intermediate-tier dungeon to the spot the dukes manor used to be before it was moved. The dungeon took me half an hour to clear completely solo. I had to take one rest, played duelist, and only allowed myself a lamptern and needle as preperation. Under typical adventurer scenarios, this should be a brisk and interesting set of combat encounters in a dungeon full of ore and crafting materials to bring back to artisans in town. On top of the gold to pay for what the artisans make from the ore.

This dungeon is lore-light and is a fortification from the dusk war. It's named has been lost to time, and only hosts the unfortunate remains of the soldiers that defended it. It is implied gently that the fortress was converted to an infirmary and research spot.

## Testing Evidence

![1](https://github.com/user-attachments/assets/da13aace-f411-420a-9510-16313d64d73d)

![2](https://github.com/user-attachments/assets/a809e866-0642-4651-8379-e5ad6385476f)

![3](https://github.com/user-attachments/assets/ba5a4aad-7e39-47c0-982d-eb902ea6f89f)

![4](https://github.com/user-attachments/assets/153e715a-1392-4559-9555-96dc951a5090)

Proof that I did in fact beat my own dungeon under reasonable gameplay expectations
![playtestproof](https://github.com/user-attachments/assets/6043e959-7306-47d4-8cbe-54450fc3df6b)


## Why It's Good For The Game

Content is good and ideally Ruby can rip this from dun_world to the new map when she needs to fill it out. Vulfanir is the direct inspiration for me making this, I really liked the level design in it and decided to dip my toes. This may be the first of several small dungeons or more reworks of existing content to make them more ours. Depends on dev vibes. 