### PR TITLE
Green Stamina Potions (and poison) interract with your Green bar. The Merchant can also import basic stamina potions.

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -16906,11 +16906,11 @@
 "heT" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
+/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+/obj/item/reagent_containers/glass/bottle/rogue/stampot,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
 "hff" = (
@@ -17178,6 +17178,10 @@
 /obj/effect/mapping_helpers/access/garrison,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"hlR" = (
+/obj/item,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "hlU" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -252018,7 +252022,7 @@ phl
 pfQ
 exD
 ehB
-sns
+hlR
 tEq
 pPy
 tvm

--- a/code/modules/cargo/packsrogue/food.dm
+++ b/code/modules/cargo/packsrogue/food.dm
@@ -21,6 +21,15 @@
 					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
 				)
 
+/datum/supply_pack/rogue/food/stampot
+	name = "Stamina Potion"
+	cost = 80
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+					/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+					/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+				)
+
 /datum/supply_pack/rogue/food/wineb
 	name = "Wine"
 	cost = 45

--- a/code/modules/cargo/packsrogue/things.dm
+++ b/code/modules/cargo/packsrogue/things.dm
@@ -11,7 +11,7 @@
 
 
 /datum/supply_pack/rogue/Things/stampot
-	name = "Stamina potion"
+	name = "Manna potion"
 	cost = 10
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/manapot)
 

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -118,9 +118,10 @@
 	metabolization_rate = REAGENTS_METABOLISM
 	alpha = 173
 
+//Turns out that Stamina is in reality the Blue bar.
 /datum/reagent/medicine/manapot/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
-		M.rogstam_add(30)
+		M.rogstam_add(30) //15 oz of mana potion = 45u. With default metabolism ticking 1u, you can regen 1350 rogstam in one bottle. A 10 Endurance character has by default 1000 rogstam maximum
 	..()
 
 /datum/reagent/medicine/strongmana
@@ -130,6 +131,7 @@
 	taste_description = "raw power"
 	metabolization_rate = REAGENTS_METABOLISM * 3
 
+//Turns out that Stamina is in reality the Blue bar.
 /datum/reagent/medicine/strongmana/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
 		M.rogstam_add(120)
@@ -145,9 +147,10 @@
 	metabolization_rate = REAGENTS_METABOLISM
 	alpha = 173
 
+//Despite the name, the green bar is actually Fatigue in the code.
 /datum/reagent/medicine/stampot/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
-		M.rogstam_add(30)
+		M.rogfat_add(-20) //The less rogfat you have, the fuller the green bar is. This should make sprinting last longer, and mitigate combat consumption. Your maximum rogfat is a tenth of your maximum rogstam
 	..()
 
 /datum/reagent/medicine/strongstam
@@ -157,9 +160,10 @@
 	taste_description = "sparkling static"
 	metabolization_rate = REAGENTS_METABOLISM * 3
 
+//Despite the name, the green bar is actually Fatigue in the code.
 /datum/reagent/medicine/strongstam/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
-		M.rogstam_add(120)
+		M.rogfat_add(-50)  //The less rogfat you have, the fuller the green bar is. Should make sprinting last forever while you chug this. But metabolizes only twice per sip. More like of a second wind if using mid combat.
 	..()
 
 /datum/reagent/medicine/antidote
@@ -363,7 +367,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 /datum/reagent/stampoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
-		M.rogstam_add(-45) //Slowly leech stamina
+		M.rogfat_add(2) //Slowly leech the green bar. Sort of similar at how fast sprinting drains your stamina. With a slow metabolization, this poison is more of a stamina blocker. Can still lock someone in stam crit if thex exhert too much while this poison is active.
 	return ..()
 
 /datum/reagent/strongstampoison
@@ -376,7 +380,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 /datum/reagent/strongstampoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
-		M.rogstam_add(-180) //Rapidly leech stamina
+		M.rogfat_add(20) //Rapidly leech stamina. Drains faster, but lasts less. Should ideally be able to neutralize someone out of combat in one application.
 	return ..()
 
 


### PR DESCRIPTION
## About The Pull Request
For the purpose of clarity, I will be using mostly the "green bar" and "blue bar" with how messy the denomination is in the code and the interface.

Currently, stamina and mana potions are functionnally identical : they replenish your blue bar. 
So I tried to code dive, and discovered that codewise, "fatigue" is the green bar, and "stamina" is the blue bar. Despite what the interface says.

So now green stamina potions and green stamina poisons will properly interact with your green bar.

Stamina potion will regen your green bar, enough to make your sprint or swift spamming longer, but still able to deplete.
Strong Stamina potions will almost refill your entire stamina in two ticks with a single sip. A good "second wind" effect.

Stamina poison very slowly drains your green bar. The main effect is blocking your natural stamina regeneration. You can still move and react, but managing your stamina will be important if you do not want to be locked.

Strong Stamina poison will actually drain your green bar to the point you can be stam critted while it is in your body. You still have some time to manoeuver or drink stamina potions at least.

As a bonus, Merchant also can important normal stamina potions, and instead of starting with 3 mana and 3 health, they start with 2 of each.

I am not sure if these values will be balanced, further testing needs to be done with different endurance and skills. But at least this should make "green bar" related chemicals 

## Testing Evidence
An example on how fast I can last on a stamina potion
https://streamable.com/6vl9wk

An example on how long I can stab people on swift.
https://streamable.com/gqmym5

## Why It's Good For The Game

Red potions are for Red Bars. Blue Potions are for Blue Bars. Green Potions should be working for Green bars !
