### PR TITLE
Alchemical Mortar Regression Fixes

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/grind_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/grind_recipes.dm
@@ -246,3 +246,13 @@
 /datum/alch_grind_recipe/transistus
 	valid_input = list(/obj/item/alch/artemisia,/obj/item/alch/benedictus,/obj/item/alch/hypericum,/obj/item/alch/salvia,/obj/item/alch/atropa,/obj/item/alch/taraxacum)
 	valid_outputs = list(/obj/item/alch/transisdust = 1)
+
+//Grinding Regression Fixes. Put interactions from old mortar not found here.
+
+/datum/alch_grind_recipe/grain
+	valid_input = /obj/item/reagent_containers/food/snacks/grown/wheat
+	valid_outputs = list(/obj/item/reagent_containers/powder/flour = 1)
+
+/datum/alch_grind_recipe/bone2
+	valid_input = /obj/item/natural/bone
+	valid_outputs = list(/obj/item/alch/bonemeal = 1)


### PR DESCRIPTION
## About The Pull Request

A while back we merged the mortar and alchemical mortar. It has come to my attention the alchemical mortar cannot process grain, or the old bone objects. This PR adds recipes for both.

## Testing Evidence

![1](https://github.com/user-attachments/assets/adc1c7e9-05c3-4efe-a1e4-ea5fd58a3ca0)

![2](https://github.com/user-attachments/assets/4a843d2a-435a-4b24-9e19-a12b59b1ab77)


## Why It's Good For The Game

It really doesn't make much sense why it has to be tail bones specifically to get bonemeal. bones is bones.
