### PR TITLE
Uncomments Frostbite

### DIFF
--- a/code/modules/spells/spell_types/wizard/spell_list.dm
+++ b/code/modules/spells/spell_types/wizard/spell_list.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(learnable_spells, (list(/obj/effect/proc_holder/spell/invoked/p
 		/obj/effect/proc_holder/spell/invoked/blindness,
 		/obj/effect/proc_holder/spell/invoked/projectile/acidsplash,
 		/obj/effect/proc_holder/spell/invoked/projectile/fireball/greater,
-//		/obj/effect/proc_holder/spell/invoked/frostbite,
+		/obj/effect/proc_holder/spell/invoked/frostbite,
 		/obj/effect/proc_holder/spell/invoked/guidance,
 		/obj/effect/proc_holder/spell/invoked/fortitude,
 		/obj/effect/proc_holder/spell/invoked/snap_freeze,


### PR DESCRIPTION
## About The Pull Request

*- Uncomments Frostbite in The Spell list
*- That's it.

## Why It's Good For The Game

*- Its another spell option for mages to use, that was commented out simply because other code bases didn't want a third ice spell

## Testing Evidence

*- Uncommented, Compiled, Localhosted. Spell was able to be learned properly, and cast properly.

