### PR TITLE
Makes projectile spell casting more obvious.

### DIFF
--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -77,6 +77,7 @@
 	var/projectiles_per_fire = 1		//Projectiles per fire. Probably not a good thing to use unless you override ready_projectile().
 	gesture_required = TRUE // Projectiles need to be aimed, and is mostly offensive.
 	ignore_los = TRUE
+	var/isquiet = FALSE
 
 /obj/effect/proc_holder/spell/invoked/projectile/proc/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)
 	return
@@ -89,6 +90,8 @@
 	if(!isturf(U) || !isturf(T))
 		return FALSE
 	fire_projectile(user, target)
+	if(!isquiet)
+		user.visible_message(span_warning("[user] casts [name]!"))
 	user.newtonian_move(get_dir(U, T))
 	update_icon()
 	start_recharge()

--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcane_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcane_bolt.dm
@@ -15,8 +15,7 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	spell_tier = 3
-	invocation = "Magicae Sagitta!"
-	invocation_type = "shout"
+	invocation_type = "none"
 	glow_color = GLOW_COLOR_ARCANE
 	glow_intensity = GLOW_INTENSITY_LOW
 	charging_slowdown = 3

--- a/code/modules/spells/spell_types/wizard/projectiles_single/fetch.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/fetch.dm
@@ -21,6 +21,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	cost = 1
 	xp_gain = TRUE
+	isquiet = TRUE
 
 /obj/projectile/magic/fetch/on_hit(target)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR adds a new variable and two whole lines of code to projectile-based spells.
All projectile spells will now create a visible message telling everyone in line of sight of the caster WHO casted WHAT, unless the new variable, creatively called "isquiet" is true.
Removes invocation from arcane bolt, because spammable spells and "shout" type incantations don't do much good for your vocal cords or the ears of people around you.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/4a81887c-1d22-4cff-9687-f7ec009793ba)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No more
**Xanthe** exclaims, "Magicae Sagitta!"
**Xanthe** exclaims, "Magicae Sagitta!"
**Xanthe** exclaims, "Magicae Sagitta!"
**Xanthe** exclaims, "Magicae Sagitta!"
filling people's chats when there's an arcane bolt user in town, plus expanded customization for possible future projectile-based spells.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
