### PR TITLE
Completely rework invocation messages

### DIFF
--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -77,7 +77,6 @@
 	var/projectiles_per_fire = 1		//Projectiles per fire. Probably not a good thing to use unless you override ready_projectile().
 	gesture_required = TRUE // Projectiles need to be aimed, and is mostly offensive.
 	ignore_los = TRUE
-	var/isquiet = FALSE
 
 /obj/effect/proc_holder/spell/invoked/projectile/proc/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)
 	return
@@ -90,8 +89,6 @@
 	if(!isturf(U) || !isturf(T))
 		return FALSE
 	fire_projectile(user, target)
-	if(!isquiet)
-		user.visible_message(span_warning("[user] casts [name]!"))
 	user.newtonian_move(get_dir(U, T))
 	update_icon()
 	start_recharge()

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -9,7 +9,9 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = 'sound/magic/heal.ogg'
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Miracle!")
+	invocation_emote_self = span_warning("I cast Miracle!")
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
 	recharge_time = 10 SECONDS
@@ -157,11 +159,12 @@
 	range = 4
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
-//	chargedloop = /datum/looping_sound/invokeholy
 	chargedloop = null
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/magic/heal.ogg'
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Fortify!")
+	invocation_emote_self = span_warning("I cast Fortify!")
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
 	recharge_time = 20 SECONDS
@@ -198,7 +201,9 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = list('sound/magic/regression1.ogg','sound/magic/regression2.ogg','sound/magic/regression3.ogg','sound/magic/regression4.ogg')
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Regression!")
+	invocation_emote_self = span_warning("I cast Regression!")
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
 	recharge_time = 10 SECONDS

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -11,7 +11,9 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = 'sound/magic/diagnose.ogg'
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Diagnose!")
+	invocation_emote_self = span_warning("I cast Diagnose!")
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
 	recharge_time = 5 SECONDS //very stupidly simple spell
@@ -67,7 +69,9 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = 'sound/gore/flesh_eat_03.ogg'
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Bodypart Miracle!")
+	invocation_emote_self = span_warning("I cast Bodypart Miracle!")
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
 	recharge_time = 60 SECONDS //attaching a limb is pretty intense

--- a/code/modules/spells/roguetown/acolyte/zira.dm
+++ b/code/modules/spells/roguetown/acolyte/zira.dm
@@ -53,7 +53,7 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	spell_tier = 2
-	invocation_type = "none"
+	invocation_type = "none" // No emote feedback intentionally.
 	sound = 'sound/misc/area.ogg' //This sound doesnt play for some reason. Fix me.
 	associated_skill = /datum/skill/magic/arcane
 	antimagic_allowed = TRUE

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -359,6 +359,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			else
 				user.whisper(invocation)
 		if("emote")
+			invocation = replacetext(invocation, "%user%", user.name) // Regex since we can't natively pass this along
 			user.visible_message(invocation, invocation_emote_self) //same style as in mob/living/emote.dm
 
 /obj/effect/proc_holder/spell/proc/playMagSound()

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -50,7 +50,9 @@
 /obj/effect/proc_holder/spell/targeted/conjure_item
 	name = "Summon weapon"
 	desc = ""
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Summon weapon!")
+	invocation_emote_self = span_warning("I cast Summon weapon!")
 	include_user = TRUE
 	range = -1
 	clothes_req = FALSE

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -5,8 +5,9 @@
 	school = "transmutation"
 	recharge_time = 300
 	clothes_req = TRUE
-	invocation = "none"
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Ethereal Jaunt!")
+	invocation_emote_self = span_warning("I cast Ethereal Jaunt!")
 	range = -1
 	cooldown_min = 100 //50 deciseconds reduction per rank
 	include_user = TRUE

--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcane_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcane_bolt.dm
@@ -15,7 +15,9 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	spell_tier = 3
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Arcane Bolt!")
+	invocation_emote_self = span_warning("I cast Arcane Bolt!")
 	glow_color = GLOW_COLOR_ARCANE
 	glow_intensity = GLOW_INTENSITY_LOW
 	charging_slowdown = 3

--- a/code/modules/spells/spell_types/wizard/projectiles_single/fetch.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/fetch.dm
@@ -21,7 +21,6 @@
 	associated_skill = /datum/skill/magic/arcane
 	cost = 1
 	xp_gain = TRUE
-	isquiet = TRUE
 
 /obj/projectile/magic/fetch/on_hit(target)
 	. = ..()

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -10,7 +10,9 @@
 	range = 2
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
-	invocation_type = "none"
+	invocation_type = "emote"
+	invocation = span_warning("%user% casts Appraise!")
+	invocation_emote_self = span_warning("I cast Appraise!")
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
 	recharge_time = 5 SECONDS 
@@ -19,7 +21,7 @@
 
 /obj/effect/proc_holder/spell/invoked/appraise/secular
 	name = "Secular Appraise"
-	overlay_state = "appraise"
+	invocation_type = "none" // Merchants are not chuunibyou, much as it'd be funny
 	range = 2
 	associated_skill = /datum/skill/misc/reading // idk reading is like Accounting right
 	miracle = FALSE


### PR DESCRIPTION
## About The Pull Request
No longer exclusive to just projectiles! Spoken invocation takes precedence over visible message invocation; **including whispered invocation.** This should avoid stealth issues while still letting near all spells have SOME form of chat feedback. Admittedly the required replacetext is dumb but I did me best and it should be relatively inexpensive.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I ran around a bit and made sure `invocation` updated as necessary and all the visible messages were still working as intended. They are!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Spells should provide feedback when they cast unless designed around being stealthy.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
