### PR TITLE
Lowers water-to-wine alchemical transmutation's crafting difficulty by one

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -87,7 +87,7 @@
 	name = "water to wine"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/wine = 1)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 1, /datum/reagent/water = 48)
-	craftdiff = 3 //WHO THE FUCK THOUGHT SETTING THIS AT 2 WAS A GOOD IDEA? MAKE IT MAKE SENSE.
+	craftdiff = 2
 	verbage_simple = "transmute"
 
 /datum/crafting_recipe/roguetown/alchemy/g2wes


### PR DESCRIPTION
## About The Pull Request
Title.
Water to wine should be now possible by any newbie-novice alchemists by changing its craftdiff to 2 (as opposed to the current 3).
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It's a one line change so sincerely I didn't.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I'm going to assume from the funny comment that the spell was initially at level 2; which in turn made it into a pretty good leveling spell with minimal waste (as opposed to the current weirdest method of mass producing bottles from dirt and stones; taking a relative **lot** of time). This should make alchemy generally more player-friendly and way less tedious to work with.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
