### PR TITLE
[[Balance]] Removes free Spellpoints from Old people

### DIFF
--- a/code/modules/jobs/job_types/roguetown/external/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/external/adventurer/types/antag/roguemage.dm
@@ -51,7 +51,6 @@
 			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 			H.change_stat("intelligence", 1)
 			H.change_stat("perception", 1)
-			H.mind.adjust_spellpoints(2)
 		H.change_stat("intelligence", 3)
 		H.change_stat("constitution", 1)
 		H.change_stat("endurance", -1)

--- a/code/modules/jobs/job_types/roguetown/external/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/external/adventurer/types/combat/mage.dm
@@ -49,7 +49,6 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 			if(H.age == AGE_OLD)
 				H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
-				H.mind.adjust_spellpoints(2)
 			H.change_stat("intelligence", 3)
 			H.change_stat("perception", 1)
 			H.change_stat("speed", 1)

--- a/code/modules/jobs/job_types/roguetown/external/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/external/adventurer/wretch.dm
@@ -281,7 +281,6 @@
 	H.cmode_music = 'sound/music/combat_cult.ogg'
 	if(H.age == AGE_OLD)
 		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
-		H.mind.adjust_spellpoints(2)
 	H.change_stat("intelligence", 4)
 	H.change_stat("endurance", 1)
 	H.change_stat("speed", 1)

--- a/code/modules/jobs/job_types/roguetown/keep/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/keep/courtier/magician.dm
@@ -70,7 +70,6 @@
 			H.change_stat("speed", -1)
 			H.change_stat("intelligence", 1)
 			H.change_stat("perception", 1)
-			H.mind.adjust_spellpoints(1)
 			if(ishumannorthern(H))
 				belt = /obj/item/storage/belt/rogue/leather/plaquegold
 				cloak = null

--- a/code/modules/jobs/job_types/roguetown/keep/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/keep/nobility/hand.dm
@@ -186,7 +186,6 @@
 		H.change_stat("strength", -1)
 		H.change_stat("intelligence", 1)
 		H.change_stat("perception", 1)
-		H.mind.adjust_spellpoints(1)
 
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 

--- a/code/modules/jobs/job_types/roguetown/mages_university/head_mage.dm
+++ b/code/modules/jobs/job_types/roguetown/mages_university/head_mage.dm
@@ -66,4 +66,3 @@
 			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 			H.change_stat("speed", -1)
 			H.change_stat("intelligence", 1)
-			H.mind.adjust_spellpoints(2)

--- a/code/modules/jobs/job_types/roguetown/mages_university/sidefolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/mages_university/sidefolk/mage_apprentice.dm
@@ -75,7 +75,6 @@
 			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 			H.change_stat("speed", -1)
 			H.change_stat("intelligence", 1)
-			H.mind.adjust_spellpoints(1)
 		ADD_TRAIT(H, TRAIT_MAGEARMOR, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_ARCANE_T3, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_MAGIC_TUTOR, TRAIT_GENERIC)
@@ -116,4 +115,3 @@
 			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 			H.change_stat("speed", -1)
 			H.change_stat("intelligence", 1)
-			H.mind.adjust_spellpoints(1)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Removes free spellpoints granted to old characters

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->

Too many had been cheesing old age (and even giving 'but they look so young') descriptions on their characters to get free spell points on their characters, the age thing at most should be similar to all classes or even an adjustment on some _VERY_ special cases like the veteran, not a must have for cheese.

Kinda expect a third of the mage population to rejuvenate after the change..