### PR TITLE
New Guild Handler Role

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -15857,6 +15857,7 @@
 	dir = 1
 	},
 /obj/structure/chair/bench/couch/r,
+/obj/effect/landmark/start/ghandler,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "gxo" = (

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -304,7 +304,7 @@
 	/datum/job/roguetown/blacksmith,\
 	/datum/job/roguetown/merchant,\
 	/datum/job/roguetown/tailor,\
-	/datum/job/roguetown/janitor\
+	/datum/job/roguetown/janitor,\
 	/datum/job/roguetown/ghandler
 
 

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -143,6 +143,7 @@
 #define SHOPHAND				(1<<4)
 #define JANITOR					(1<<5)
 #define TAILOR					(1<<6)
+#define GHANDLER				(1<<0)
 
 #define PEASANTS					(1<<5)
 
@@ -241,18 +242,19 @@
 #define JDO_SOILSON 40
 #define JDO_JANITOR 41
 #define JDO_TAILOR 42
+#define JDO_GHANDLER 43
 
-#define JDO_VILLAGER 43
+#define JDO_VILLAGER 44
 
 /// External
-#define JDO_ADVENTURER 44
-#define JDO_PILGRIM 45
-#define JDO_MIGRANT 46
-#define JDO_BANDIT 47
-#define JDO_COURTAGENT 48
-#define JDO_WRETCH 49
+#define JDO_ADVENTURER 45
+#define JDO_PILGRIM 46
+#define JDO_MIGRANT 47
+#define JDO_BANDIT 48
+#define JDO_COURTAGENT 49
+#define JDO_WRETCH 50
 
-#define JDO_LUNATIC 50 // ALWAYS keep lunatic last. It's a reward role for being a true sport.
+#define JDO_LUNATIC 10 // ALWAYS keep lunatic last. It's a reward role for being a true sport.
 
 #define MANOR_ROLES \
 	/datum/job/roguetown/jester,\
@@ -302,8 +304,8 @@
 	/datum/job/roguetown/blacksmith,\
 	/datum/job/roguetown/merchant,\
 	/datum/job/roguetown/tailor,\
-	/datum/job/roguetown/janitor
-
+	/datum/job/roguetown/janitor\
+	/datum/job/roguetown/ghandler
 
 
 #define WANDERER_ROLES \

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -143,7 +143,7 @@
 #define SHOPHAND				(1<<4)
 #define JANITOR					(1<<5)
 #define TAILOR					(1<<6)
-#define GHANDLER				(1<<0)
+#define GHANDLER				(1<<7)
 
 #define PEASANTS					(1<<5)
 
@@ -254,7 +254,7 @@
 #define JDO_COURTAGENT 49
 #define JDO_WRETCH 50
 
-#define JDO_LUNATIC 10 // ALWAYS keep lunatic last. It's a reward role for being a true sport.
+#define JDO_LUNATIC 51 // ALWAYS keep lunatic last. It's a reward role for being a true sport.
 
 #define MANOR_ROLES \
 	/datum/job/roguetown/jester,\

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -243,6 +243,7 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_SERVANT		"CAT_SERVANT"		// Servant's aesthetic choices.
 #define CTAG_CAPTAIN		"CAT_CAPTAIN"		// Handles Captain class selector
 #define CTAG_WAPPRENTICE	"CTAG_WAPPRENTICE"	// Mage Apprentice Classes - Handles Mage Apprentices class selector
+#define CTAG_GHANDLER		"CTAG_GHANDLER"		// Adventurers Guild Handler class
 
 /*
 	Defines for the triumph buy datum categories

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -257,6 +257,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	name = /datum/job/roguetown/lunatic::title
 	icon_state = "arrow"
 
+/obj/effect/landmark/start/ghandler
+	name = /datum/job/roguetown/ghandler::title
+	icon_state = "arrow"
+
 //yrf
 
 /obj/effect/landmark/start/squire

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -71,7 +71,7 @@
 	if(tag)
 		switch(tag)
 			if("gen")
-				return list("shrink" = 0.4,	
+				return list("shrink" = 0.4,
 "sx" = -6,
 "sy" = -3,
 "nx" = 13,
@@ -249,6 +249,9 @@
 
 /obj/item/storage/keyring/innkeep
 	keys = list(/obj/item/roguekey/tavern, /obj/item/roguekey/tavernkeep, /obj/item/roguekey/roomviii, /obj/item/roguekey/roomvii, /obj/item/roguekey/roomvi, /obj/item/roguekey/roomv, /obj/item/roguekey/roomiv, /obj/item/roguekey/roomiii, /obj/item/roguekey/roomii, /obj/item/roguekey/roomi, /obj/item/roguekey/fancyroomi, /obj/item/roguekey/fancyroomii, /obj/item/roguekey/fancyroomiii, /obj/item/roguekey/fancyroomiv, /obj/item/roguekey/fancyroomv)
+
+/obj/item/storage/keyring/ghandler
+	keys = list (/obj/item/roguekey/tavern, /obj/item/roguekey/adventurers_guild)
 
 /obj/item/storage/keyring/priest
 	keys = list(/obj/item/roguekey/priest, /obj/item/roguekey/church, /obj/item/roguekey/graveyard)

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -501,3 +501,14 @@
 	sewrepair = TRUE
 	flags_inv = null
 	slot_flags = ITEM_SLOT_SHIRT
+
+/obj/item/clothing/suit/roguetown/shirt/guildwaistcoat
+	name= "Guild Waistcoat"
+	desc = "A fine delicate waistcoat worn by the travelling beurocrats of Rasura's various Guilds. It's a little tight around the middle."
+	icon_state = "grenzelshirt"
+	item_state = "grenzelshirt"
+	body_parts_covered = CHEST|GROIN|ARMS|VITALS
+	boobed = FALSE
+	r_sleeve_status = SLEEVE_NORMAL
+	l_sleeve_status = SLEEVE_NORMAL
+	flags_inv = HIDECROTCH|HIDEBOOB

--- a/code/modules/jobs/job_types/roguetown/town/yeomen/ghandler.dm
+++ b/code/modules/jobs/job_types/roguetown/town/yeomen/ghandler.dm
@@ -15,7 +15,7 @@
 	give_bank_account = 43
 	min_pq = -4
 	max_pq = null
-	round_contrib_points = 3
+	round_contrib_points = 2
 
 
 /datum/job/roguetown/ghandler/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
@@ -89,7 +89,7 @@
 	beltl = /obj/item/storage/keyring/ghandler
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 	id = /obj/item/scomstone/
-	backpack_contents = list(/obj/item/paper = 2, /obj/item/natural/feather = 1)
+	backpack_contents = list(/obj/item/paper = 4, /obj/item/natural/feather = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/town/yeomen/ghandler.dm
+++ b/code/modules/jobs/job_types/roguetown/town/yeomen/ghandler.dm
@@ -1,0 +1,118 @@
+/datum/job/roguetown/ghandler
+	title = "Guild Handler"
+	flag = GHANDLER
+	department_flag = YEOMEN
+	selection_color = JCOLOR_YEOMAN
+	faction = "Station"
+	total_positions = 1
+	spawn_positions = 1
+
+	allowed_races = RACES_ALL_KINDS
+
+	tutorial = "You are the proud handler for the local branch of the Rasurian Adventurer's Guild. You've taken upon yourself the task of wrangling the constant flow of adventurers and treasure-seekers into the March. It is a job of constant diplomacy and occasional action, keeping the local lords happy while arranging quests and affairs for the adventurers."
+	advclass_cat_rolls = list(CTAG_GHANDLER = 20)
+	display_order = JDO_GHANDLER
+	give_bank_account = 43
+	min_pq = -4
+	max_pq = null
+	round_contrib_points = 3
+
+
+/datum/job/roguetown/ghandler/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.advsetup = 1
+		H.invisibility = INVISIBILITY_MAXIMUM
+		H.become_blind("advsetup")
+
+
+/datum/advclass/ghandler/ace
+	name = "Ace Adventurer"
+	tutorial = "You were the best of the best. Being among the best of the Guild comes with promotion but what they don't tell you is that promotion comes with a desk, paperwork and endless responsibility. Your talent might be rusty but you can still pack a punch."
+	outfit = /datum/outfit/job/roguetown/ghandler/ace
+
+	category_tags = list(CTAG_GHANDLER)
+
+/datum/outfit/job/roguetown/ghandler/ace/pre_equip(mob/living/carbon/human/H)
+	..()
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	backl = /obj/item/storage/backpack/rogue/satchel
+	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	belt = /obj/item/storage/belt/rogue/leather/black
+	beltl = /obj/item/storage/keyring/ghandler
+	beltr = /obj/item/rogueweapon/mace/silver
+	id = /obj/item/scomstone/
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/paper = 2, /obj/item/natural/feather = 1)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
+		H.change_stat("strength", 2)
+		H.change_stat("perception", 1)
+		H.change_stat("intelligence", 2)
+		H.change_stat("constitution", 1)
+		H.change_stat("endurance", 1)
+		H.change_stat("fortune", 1)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+
+/datum/advclass/ghandler/receptionist
+	name = "Guild Receptionist"
+	tutorial = "You're not a fighter. As the Adventuring Guild grew from a twinkle in an enterprising eye to having holds all over Rasura the reality of the work set in. Someone needs to write paperwork, assign pay and communicate with local lords and ladies lest someones head gets lopped. That's where you come in. Booksmart and clever and respected by every toughbooted adventurer that walks in the door. "
+	outfit = /datum/outfit/job/roguetown/ghandler/receptionist
+
+	category_tags = list(CTAG_GHANDLER)
+
+/datum/outfit/job/roguetown/ghandler/receptionist/pre_equip(mob/living/carbon/human/H)
+	..()
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/fencer
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	pants = /datum/supply_pack/rogue/apparel/trousers/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	backl = /obj/item/storage/backpack/rogue/satchel
+	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	belt = /obj/item/storage/belt/rogue/leather/black
+	beltl = /obj/item/storage/keyring/ghandler
+	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+	id = /obj/item/scomstone/
+	backpack_contents = list(obj/item/paper = 2, /obj/item/natural/feather = 1)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
+		H.change_stat("perception", 2)
+		H.change_stat("intelligence", 2)
+		H.change_stat("constitution", 1)
+		H.change_stat("endurance", 1)
+		H.change_stat("fortune", 2)
+		H.change_stat("speed", 1)

--- a/code/modules/jobs/job_types/roguetown/town/yeomen/ghandler.dm
+++ b/code/modules/jobs/job_types/roguetown/town/yeomen/ghandler.dm
@@ -35,9 +35,8 @@
 	category_tags = list(CTAG_GHANDLER)
 
 /datum/outfit/job/roguetown/ghandler/ace/pre_equip(mob/living/carbon/human/H)
-	..()
 	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	shirt = /obj/item/clothing/suit/roguetown/shirt/guildwaistcoat
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	backl = /obj/item/storage/backpack/rogue/satchel
@@ -81,18 +80,16 @@
 	category_tags = list(CTAG_GHANDLER)
 
 /datum/outfit/job/roguetown/ghandler/receptionist/pre_equip(mob/living/carbon/human/H)
-	..()
-	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/fencer
-	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-	pants = /datum/supply_pack/rogue/apparel/trousers/leather
+	shirt = /obj/item/clothing/suit/roguetown/shirt/guildwaistcoat
+	pants = /obj/item/clothing/under/roguetown/tights/black
+	neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	backl = /obj/item/storage/backpack/rogue/satchel
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/keyring/ghandler
-	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 	id = /obj/item/scomstone/
-	backpack_contents = list(obj/item/paper = 2, /obj/item/natural/feather = 1)
+	backpack_contents = list(/obj/item/paper = 2, /obj/item/natural/feather = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
@@ -100,12 +97,12 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -104,7 +104,8 @@ GLOBAL_LIST_INIT(yeoman_positions, list(
 	/datum/job/roguetown/blacksmith::title,
 	/datum/job/roguetown/bapprentice::title,
 	/datum/job/roguetown/janitor::title,
-	/datum/job/roguetown/tailor::title
+	/datum/job/roguetown/tailor::title,
+	/datum/job/roguetown/ghandler::title,
 ))
 
 GLOBAL_LIST_INIT(peasant_positions, list(

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1348,6 +1348,7 @@
 #include "code\modules\jobs\job_types\roguetown\town\sidefolk\smith_apprentice.dm"
 #include "code\modules\jobs\job_types\roguetown\town\yeomen\barkeep.dm"
 #include "code\modules\jobs\job_types\roguetown\town\yeomen\blacksmith.dm"
+#include "code\modules\jobs\job_types\roguetown\town\yeomen\ghandler.dm"
 #include "code\modules\jobs\job_types\roguetown\town\yeomen\janitor.dm"
 #include "code\modules\jobs\job_types\roguetown\town\yeomen\merchant.dm"
 #include "code\modules\jobs\job_types\roguetown\town\yeomen\tailor.dm"


### PR DESCRIPTION
## About The Pull Request

Introducing the Adventurer's Guild Handler, meant to bring in a new age of organised adventure and fun!

Added the Guild Handler role who runs the small Adventurer Guild building in town. They have the responsibilities of being a go to advisor and quest giver for the other Adventurer characters. 

Added 2 Subclasses, an old Ace Adventurer who has some moderate combat stats who can help and train adventurers, and the Guild Receptionist who has more practical skills for upkeeping equipment and doing the paperwork needed.

Both classes start with understated gear, as they are not meant to be charging into battle all the time themselves. They also start with an SCOMstone to help spread news and organise the town!

## Testing Evidence

![Screenshot 2025-06-17 185928](https://github.com/user-attachments/assets/2a2c1d37-eb86-441e-8130-8c252833c72f)
![image](https://github.com/user-attachments/assets/362fa97c-7f25-4c1c-b773-9e6bb07656a3)


## Why It's Good For The Game

Part of 'The Plan' to bring the Adventurers together into more of a faction, including allying with the Tavern as a unified faction. 
A role that focuses on helping the adventuring culture on the server and bridging the gap it can have between adventurers and the keep, church or regular peasants. 

Should work really well with the new notice boards!

## To Do in Future Updates

I wanted to give them unique clothing, but that was outside of the scope right now. The repurposed old grenzel-shirt I used is somewhat buggy right now but can definitely be fixed.

We want in the future a Guild Liscence system, even if its as simple as a tool tip that pops up when someone with a Liscence is examined. 