### PR TITLE
Toybox balance

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -393,7 +393,7 @@
 /area/rogue/indoors/town)
 "ahF" = (
 /obj/structure/rack/rogue/shelf/biggest,
-/obj/item/bedroll,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/gadgets,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "ahI" = (
@@ -4987,7 +4987,7 @@
 /area/rogue/outdoors/town)
 "bMd" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/effect/spawner/lootdrop/potion_vitals,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dungeon/old_university)
 "bMf" = (
@@ -8349,9 +8349,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "cXs" = (
 /obj/structure/rack/rogue,
-/obj/item/roguegear{
-	pixel_x = -2
-	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon/gadgets,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/dungeon/old_university)
 "cXw" = (
@@ -8500,10 +8498,7 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "das" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/glass/bottle/rogue/poison{
-	pixel_x = 0;
-	pixel_y = 11
-	},
+/obj/effect/spawner/lootdrop/potion_poisons,
 /turf/open/floor/rogue/tile/masonic{
 	dir = 8
 	},
@@ -12707,6 +12702,7 @@
 /obj/structure/floordoor{
 	redstone_id = "tbmoneyroom"
 	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon/gadgets,
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "eAR" = (
@@ -12853,10 +12849,7 @@
 /area/rogue/under/cave/dungeon/fort_dusk)
 "eDk" = (
 /obj/structure/table/wood/fancy/cyan,
-/obj/item/reagent_containers/glass/bottle/rogue/elfred{
-	pixel_x = 3;
-	pixel_y = 11
-	},
+/obj/effect/spawner/lootdrop/potion_stats,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "eDp" = (
@@ -16108,7 +16101,8 @@
 /area/rogue/indoors/cave)
 "fKk" = (
 /obj/structure/closet/crate/roguecloset/dark,
-/obj/item/reagent_containers/glass/bottle/waterskin/purifier,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/gadgets,
+/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "fKG" = (
@@ -18080,7 +18074,7 @@
 "guK" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/item/reagent_containers/glass/cup/golden,
-/obj/item/sharpener,
+/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "guN" = (
@@ -21270,10 +21264,7 @@
 /area/rogue/indoors/town/tavern)
 "hBL" = (
 /obj/structure/table/wood/fancy/green,
-/obj/item/reagent_containers/glass/bottle/rogue/elfblue{
-	pixel_x = 0;
-	pixel_y = 12
-	},
+/obj/effect/spawner/lootdrop/potion_vitals,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "hBM" = (
@@ -24028,6 +24019,11 @@
 "iyF" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/closet/crate/chest/wicker,
+/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
+/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
 	},
@@ -31631,7 +31627,7 @@
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
 "llG" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/effect/spawner/lootdrop/potion_vitals,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "llM" = (
@@ -32803,10 +32799,7 @@
 /area/rogue/indoors/town/church/chapel)
 "lGA" = (
 /obj/structure/table/wood/fancy/red,
-/obj/item/reagent_containers/glass/bottle/rogue/stampot{
-	pixel_x = -3;
-	pixel_y = 9
-	},
+/obj/effect/spawner/lootdrop/potion_vitals,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "lGH" = (
@@ -37724,7 +37717,7 @@
 /obj/structure/table/wood{
 	icon_state = "largetable"
 	},
-/obj/item/weaponcrafting/barrel,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/gadgets,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/under/cave/dungeon/old_university)
 "ntw" = (
@@ -41210,10 +41203,6 @@
 /obj/effect/mapping_helpers/access/antag/underking,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains)
-"oGr" = (
-/obj/item/needle,
-/turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/woods)
 "oGu" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -42410,10 +42399,7 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "pdX" = (
 /obj/structure/table/wood/fancy/orange,
-/obj/item/reagent_containers/glass/bottle/rogue/manapot{
-	pixel_x = -2;
-	pixel_y = 9
-	},
+/obj/effect/spawner/lootdrop/potion_stats,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "pee" = (
@@ -53192,7 +53178,7 @@
 /area/rogue/under/cave/dungeon/dungeon1/gethsmane)
 "sYr" = (
 /obj/structure/closet/crate/roguecloset/crafted,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/gadgets,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "sYw" = (
@@ -62295,10 +62281,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"woe" = (
-/obj/item/flashlight/flare/torch/lantern/bronzelamptern,
-/turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/woods)
 "woi" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/carpet/royalblack,
@@ -63768,7 +63750,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/effect/spawner/lootdrop/potion_vitals,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "wWh" = (
@@ -279792,7 +279774,7 @@ eMx
 eMx
 eMx
 lkt
-oGr
+fQI
 fQI
 fQI
 qXm
@@ -280244,7 +280226,7 @@ eMx
 eMx
 eMx
 lkt
-woe
+fQI
 fQI
 fQI
 qXm

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -24474,6 +24474,10 @@
 "iIe" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cave/dungeon/vulnafir)
+"iIm" = (
+/obj/item/storage/belt/rogue/pouch/coins/rich,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/under/cave/dungeon/toybox_dungeon)
 "iIp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -52914,13 +52918,13 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/powder/spice{
-	pixel_x = 0;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/glass/cup/golden{
 	pixel_x = -9;
 	pixel_y = -6
+	},
+/obj/item/reagent_containers/powder/spice{
+	pixel_x = 0;
+	pixel_y = 5
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
@@ -56134,6 +56138,13 @@
 	icon_state = "plating2"
 	},
 /area/rogue/under/cave/dungeon/toybox_dungeon)
+"udz" = (
+/obj/structure/fluff/littlebanners{
+	pixel_y = -5
+	},
+/obj/item/storage/belt/rogue/pouch/coins/rich,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/under/cave/dungeon/toybox_dungeon)
 "udD" = (
 /obj/effect/decal/wood/herringbone{
 	dir = 5
@@ -56887,7 +56898,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "uqF" = (
-/obj/item/gun/ballistic/arquebus,
+/obj/item/riddleofsteel,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
 "uqH" = (
@@ -66399,13 +66410,13 @@
 	pixel_x = 0;
 	pixel_y = 7
 	},
-/obj/item/reagent_containers/powder/sugar{
-	pixel_x = 0;
-	pixel_y = 12
-	},
 /obj/item/candle/yellow/lit{
 	pixel_x = 11;
 	pixel_y = -5
+	},
+/obj/item/reagent_containers/powder/sugar{
+	pixel_x = 0;
+	pixel_y = 12
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/under/cave/dungeon/toybox_dungeon)
@@ -509450,7 +509461,7 @@ fZQ
 voP
 rdN
 voP
-fZQ
+udz
 rdN
 nGW
 oAX
@@ -509899,7 +509910,7 @@ jdl
 rdN
 voP
 fZQ
-rdN
+iIm
 rdN
 rdN
 fZQ
@@ -511715,7 +511726,7 @@ fZQ
 rdN
 ljy
 voP
-rdN
+iIm
 fZQ
 uFN
 nGW
@@ -512620,7 +512631,7 @@ rdN
 ljy
 voP
 rdN
-fZQ
+udz
 uFN
 whh
 cQk
@@ -514418,7 +514429,7 @@ nGW
 jdl
 rdN
 rdN
-fZQ
+udz
 voP
 voP
 rdN
@@ -514873,7 +514884,7 @@ rdN
 iTa
 rdN
 rdN
-rdN
+iIm
 iTa
 rdN
 flX

--- a/_maps/templates/smalldungeons.dm
+++ b/_maps/templates/smalldungeons.dm
@@ -362,3 +362,17 @@
 		/obj/item/book/granter/spell/blackstone/greaterfireball = 1
 	)
 	lootcount = 1
+
+/obj/effect/spawner/lootdrop/roguetown/dungeon/gadgets
+	loot = list(
+		//Adventuring Gear
+		/obj/item/bedroll = 3,
+		/obj/item/reagent_containers/glass/bottle/waterskin = 3,
+		/obj/item/reagent_containers/glass/bottle/waterskin/purifier = 1,
+		/obj/item/storage/gadget/messkit = 3,
+		/obj/item/gwstrap = 2,
+		/obj/item/flashlight/flare/torch/lantern/bronzelamptern = 2,
+		/obj/item/storage/backpack/rogue/artibackpack = 1,
+		/obj/item/grapplinghook = 1
+	)
+	lootcount = 1

--- a/code/modules/mob/living/carbon/human/npc/toy_jester.dm
+++ b/code/modules/mob/living/carbon/human/npc/toy_jester.dm
@@ -124,8 +124,6 @@ GLOBAL_LIST_INIT(toyjester_aggro, world.file2list("strings/rt/toyjesteraggroline
 			shirt = /obj/item/clothing/suit/roguetown/shirt/jester
 			pants = /obj/item/clothing/under/roguetown/tights/jester
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-			if(prob(50))
-				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 			mask = /obj/item/clothing/mask/rogue/facemask
 			if(prob(50))
 				mask = /obj/item/clothing/mask/rogue/ragmask/black
@@ -154,8 +152,6 @@ GLOBAL_LIST_INIT(toyjester_aggro, world.file2list("strings/rt/toyjesteraggroline
 			pants = /obj/item/clothing/under/roguetown/tights/jester
 			cloak = /obj/item/clothing/cloak/cape
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-			if(prob(50))
-				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 			mask = /obj/item/clothing/mask/rogue/facemask
 			if(prob(50))
 				mask = /obj/item/clothing/mask/rogue/ragmask/black
@@ -169,7 +165,7 @@ GLOBAL_LIST_INIT(toyjester_aggro, world.file2list("strings/rt/toyjesteraggroline
 			shoes = /obj/item/clothing/shoes/roguetown/jester
 			H.STASTR = rand(15,17)
 			H.STASPD = rand(15,17)
-			H.STACON = rand(15,17)
+			H.STACON = rand(16,18)
 			H.STAEND = rand(14,16)
 			H.STAPER = rand(16,18)
 			H.STAINT = rand(12,13)
@@ -180,8 +176,6 @@ GLOBAL_LIST_INIT(toyjester_aggro, world.file2list("strings/rt/toyjesteraggroline
 			shirt = /obj/item/clothing/suit/roguetown/shirt/jester
 			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-			if(prob(50))
-				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 			mask = /obj/item/clothing/mask/rogue/facemask
 			head = /obj/item/clothing/head/roguetown/helmet/skullcap
 			neck = /obj/item/clothing/neck/roguetown/gorget


### PR DESCRIPTION
## About The Pull Request

We had a very good live test last night of Guiseppe's Toybox. The following alterations have been made:

-Removal of debug items outside of the toybox I used for playtesting but forgot to delete. Oops.

-Removal of heavy leather bracers from toybox mobs. a bit too powerful to be handed out to players that trivially.

-Addition of a lootspawner for adventuring gadgets. Its loot table includes: bedroll, waterskin, purifying waterskin, cooling backpack, a messkit, a greatweapon strap, a bronze lamptern, and a grappling hook. The loot table is weighted so bedrolls, mess kits, and normal water skins are the most common. Grappling hooks are as rare as a greater fireball scroll.

-Replaced static potion spawns with beneficial potions chosen from a loot table.

-Added 4 copiettes to the toybox for large adventuring expeditions. If you have a healer, rogue, fighter, and support class, you should be able to finish this dungeon by long resting in it and not having to leave. This makes it more likely to do so with the addition of prepared travel rations.

## Testing Evidence

Dun_World compiles still after these tiny alterations. Heres screenshots of the gadget spawner working.
![1](https://github.com/user-attachments/assets/d7651a47-9b68-4be4-985e-96bb7a035f43)

![2](https://github.com/user-attachments/assets/930c9937-63b1-4e16-8fd4-54cb317f4de3)



## Why It's Good For The Game

I am physically incapable of not implementing feedback given to me by the players that run my content. I am a try hard. It will be perfect, and it will be solaris's, or I will die trying.
