### PR TITLE
Toy Jester Rebalance

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/toy_jester.dm
+++ b/code/modules/mob/living/carbon/human/npc/toy_jester.dm
@@ -120,73 +120,58 @@ GLOBAL_LIST_INIT(toyjester_aggro, world.file2list("strings/rt/toyjesteraggroline
 	var/toyclass = rand(1,3)
 	switch(toyclass)
 		if(1) //Jester
-			armor = /obj/item/clothing/suit/roguetown/armor/leather
 			shirt = /obj/item/clothing/suit/roguetown/shirt/jester
 			pants = /obj/item/clothing/under/roguetown/tights/jester
-			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			mask = /obj/item/clothing/mask/rogue/facemask
 			if(prob(50))
 				mask = /obj/item/clothing/mask/rogue/ragmask/black
 			head = /obj/item/clothing/head/roguetown/jester
-			if(prob(50))
-				head = /obj/item/clothing/head/roguetown/helmet/leather
-			neck = /obj/item/clothing/neck/roguetown/leather
-			if(prob(50))
-				neck = /obj/item/clothing/neck/roguetown/gorget
-			gloves = /obj/item/clothing/gloves/roguetown/angle
 			shoes = /obj/item/clothing/shoes/roguetown/jester
-			H.STASTR = rand(8,20)
-			H.STASPD = rand(16,18)
-			H.STACON = rand(16,18)
-			H.STAEND = rand(14,16)
-			H.STAPER = rand(12,14)
-			H.STAINT = rand(12,14)
+			H.STASTR = rand(12,16)
+			H.STASPD = rand(10,16)
+			H.STACON = rand(12,16)
+			H.STAEND = rand(12,16)
+			H.STAPER = rand(10,16)
+			H.STAINT = rand(8,10)
 			if(prob(50))
 				r_hand = /obj/item/rogueweapon/knuckles/bronzeknuckles
 				l_hand = /obj/item/rogueweapon/knuckles/bronzeknuckles
 			else
 				r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
 		if(2) //Toy Arquebusier
-			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 			shirt = /obj/item/clothing/suit/roguetown/shirt/jester
 			pants = /obj/item/clothing/under/roguetown/tights/jester
 			cloak = /obj/item/clothing/cloak/cape
-			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			mask = /obj/item/clothing/mask/rogue/facemask
 			if(prob(50))
 				mask = /obj/item/clothing/mask/rogue/ragmask/black
 			head = /obj/item/clothing/head/roguetown/helmet/tricorn
 			if(prob(1))
 				head = /obj/item/clothing/head/roguetown/helmet/tricorn/lucky
-			neck = /obj/item/clothing/neck/roguetown/leather
-			if(prob(50))
-				neck = /obj/item/clothing/neck/roguetown/gorget
-			gloves = /obj/item/clothing/gloves/roguetown/angle
 			shoes = /obj/item/clothing/shoes/roguetown/jester
-			H.STASTR = rand(15,17)
-			H.STASPD = rand(15,17)
-			H.STACON = rand(16,18)
-			H.STAEND = rand(14,16)
-			H.STAPER = rand(16,18)
-			H.STAINT = rand(12,13)
+			H.STASTR = rand(12,16)
+			H.STASPD = rand(10,16)
+			H.STACON = rand(12,16)
+			H.STAEND = rand(12,16)
+			H.STAPER = rand(10,16)
+			H.STAINT = rand(8,10)
 			r_hand = /obj/item/rogueweapon/halberd/toyarquebus
-			beltl = /obj/item/ammopouch/bullets
 		if(3) //Toy Knight
-			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
 			shirt = /obj/item/clothing/suit/roguetown/shirt/jester
-			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+			pants = /obj/item/clothing/under/roguetown/tights/jester
 			mask = /obj/item/clothing/mask/rogue/facemask
-			head = /obj/item/clothing/head/roguetown/helmet/skullcap
-			neck = /obj/item/clothing/neck/roguetown/gorget
-			gloves = /obj/item/clothing/gloves/roguetown/chain/iron
+			if(prob(50))
+				mask = /obj/item/clothing/mask/rogue/ragmask/black
+			head = /obj/item/clothing/head/roguetown/jester
+			if(prob(50))
+				head = /obj/item/clothing/head/roguetown/helmet/skullcap
 			shoes = /obj/item/clothing/shoes/roguetown/jester
-			H.STASTR = rand(16,18)
-			H.STASPD = rand(16,18)
-			H.STACON = rand(16,18)
-			H.STAEND = rand(14,16)
-			H.STAPER = rand(12,14)
-			H.STAINT = rand(12,14)
+			H.STASTR = rand(12,16)
+			H.STASPD = rand(10,16)
+			H.STACON = rand(12,16)
+			H.STAEND = rand(12,16)
+			H.STAPER = rand(10,16)
+			H.STAINT = rand(8,10)
 			if(prob(50))
 				r_hand = /obj/item/rogueweapon/sword/iron
 				l_hand = /obj/item/rogueweapon/shield/heater


### PR DESCRIPTION

## About The Pull Request

More feedback, more iterations. This time it is agreed the new mobs are a little too hard to kill for the quantity of them. To account for this, the following changes are made:

1. All jesters are unarmored, except the knight sub-variant that has a CHANCE to spawn with a skullcap now.
2. Stat nerf. Perception and speed now vary between 10 and 16 at random, instead of the inherited drow 16-18. This should make them MUCH easier to get a solid hit in. Everything else has been lowered to 12-16, except intelligence, which is their stat weakness at 8-10 at random. Ideally this makes mages hurt them more. 
3. They keep the iron masks for flavor reasons. Its fuckin spooky.

## Testing Evidence

I got lucky and all three variations spawned in the foyer.
![1](https://github.com/user-attachments/assets/d49568d1-e77e-47b4-92c7-d2fa3a692326)


## Why It's Good For The Game

No one will look forwards to running the dungeon again if they dread the repair grind it entails. A well formed team should be able to more surgically sweep and clear now and mitigate damage taken and be rewarded for it. 
