### PR TITLE
Jester Kneestinger Immunity

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/toy_jester.dm
+++ b/code/modules/mob/living/carbon/human/npc/toy_jester.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_INIT(toyjester_aggro, world.file2list("strings/rt/toyjesteraggroline
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOROGSTAM, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_KNEESTINGER_IMMUNITY, TRAIT_GENERIC) //Tamari devouts log off
 	equipOutfit(new /datum/outfit/job/roguetown/human/species/construct/metal/toyjester)
 	gender = pick(MALE, FEMALE)
 	regenerate_icons()


### PR DESCRIPTION
## About The Pull Request

With the jester nerf a kneestinger strategy is TOO effective. Any druid can solo the dungeon at anytime with no danger, forever. In response, they are now immune to kneestingers. Something something, constructs have no nerves to shock.

## Testing Evidence

Its a one line change copied from the trollbog.dm trust me it works.

## Why It's Good For The Game

Gently avoids an undesirable one-person catch all solution to the dungeon. 
