### PR TITLE
[Balance] Arcane Spells XP, Feather Fall cast Rate & Classes adj.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/keep/nobility/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/keep/nobility/noble.dm
@@ -76,7 +76,7 @@
 /datum/outfit/job/roguetown/heir/bookworm/pre_equip(mob/living/carbon/human/H)
 	..()
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_ARCANE_T1, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_ARCANE_T2, TRAIT_GENERIC)
 	if(should_wear_masc_clothes(H))
 		pants = /obj/item/clothing/under/roguetown/tights/random
 		armor = /obj/item/clothing/suit/roguetown/armor/longcoat

--- a/code/modules/jobs/job_types/roguetown/mages_university/artificer.dm
+++ b/code/modules/jobs/job_types/roguetown/mages_university/artificer.dm
@@ -40,6 +40,7 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 
 	head = /obj/item/clothing/head/roguetown/articap
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket
@@ -62,4 +63,5 @@
 	H.change_stat("intelligence", 3) //Nerd
 	H.change_stat("endurance", 2) //Innate mining should have some gains
 	H.change_stat("constitution", 1)
-	ADD_TRAIT(H, TRAIT_ARCANE_T1, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MAGIC_TALENT, TRAIT_GENERIC) // Arcane potential Trait, so they dont get to T2
+	H.mind?.adjust_spellpoints(2)

--- a/code/modules/jobs/job_types/roguetown/town/yeomen/janitor.dm
+++ b/code/modules/jobs/job_types/roguetown/town/yeomen/janitor.dm
@@ -43,6 +43,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/roguekey/janitor
 	backr = /obj/item/storage/backpack/rogue/satchel
@@ -59,4 +60,5 @@
 	H.change_stat("intelligence", 1)
 	H.change_stat("speed", 1) //5 points (weighted) 
 	ADD_TRAIT(H, TRAIT_CICERONE, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_ARCANE_T1, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MAGIC_TALENT, TRAIT_GENERIC) // Arcane potential Trait, so they dont get to T2
+	H.mind?.adjust_spellpoints(2)

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/darkvision.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/darkvision.dm
@@ -25,6 +25,7 @@
 	icon_state = "pulling"
 	icon_state = "grabbing_greyscale"
 	color = "#3FBAFD"
+	associated_skill = /datum/skill/magic/arcane
 
 /obj/item/melee/touch_attack/darkvision/attack_self()
 	attached_spell.remove_hand()
@@ -36,6 +37,7 @@
 			return
 		spelltarget.apply_status_effect(/datum/status_effect/buff/darkvision)
 		user.rogfat_add(80)
+		user.mind.add_sleep_experience(associated_skill, 48, FALSE) // XP Magical number should be 60% of stamina used (so 80*0.6 = 48)
 		if(spelltarget != user)
 			user.visible_message("[user] draws a glyph in the air and touches [spelltarget] with an arcane focus.")
 		else

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/enlarge.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/enlarge.dm
@@ -19,6 +19,7 @@
 	glow_intensity = GLOW_INTENSITY_LOW
 	overlay_state = "rune1"
 	range = 7
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/enlarge/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/featherfall.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/featherfall.dm
@@ -6,7 +6,7 @@
 	school = "transmutation"
 	releasedrain = 50
 	chargedrain = 0
-	chargetime = 10 SECONDS
+	chargetime = 5 SECONDS
 	recharge_time = 2 MINUTES
 	warnie = "spellwarning"
 	no_early_release = TRUE

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
@@ -19,6 +19,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "rune5"
 	range = 7
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/leap/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/nondetection.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/nondetection.dm
@@ -24,6 +24,7 @@
 	icon_state = "pulling"
 	icon_state = "grabbing_greyscale"
 	color = "#3FBAFD"
+	associated_skill = /datum/skill/magic/arcane
 
 /obj/item/melee/touch_attack/nondetection/attack_self()
 	attached_spell.remove_hand()
@@ -58,6 +59,7 @@
 
 		qdel(sacrifice)
 		ADD_TRAIT(spelltarget, TRAIT_ANTISCRYING, MAGIC_TRAIT)
+		user.mind.add_sleep_experience(associated_skill, 15, FALSE) // XP Magic number, just set it to 15, need to cast it 100 times to get to legendary from 0
 		if(spelltarget != user)
 			user.visible_message("[user] draws a glyph in the air and blows some ash onto [spelltarget].")
 		else

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_armor.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_armor.dm
@@ -21,6 +21,7 @@
 	antimagic_allowed = FALSE
 	charging_slowdown = 3
 	cost = 2
+	xp_gain = TRUE
 	spell_tier = 2 // Spellblade tier.
 
 	invocation = "Armatura Creetur!"

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
@@ -20,6 +20,7 @@
 	antimagic_allowed = FALSE
 	charging_slowdown = 3
 	cost = 1
+	xp_gain = TRUE
 	spell_tier = 2 // Spellblade tier.
 
 	invocation = "Arma Exoriantur!"

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/thunderstrike.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/thunderstrike.dm
@@ -23,6 +23,7 @@
 	var/strike_delay = 3 // delay between each individual strike. 3 delays seems to make someone stupid able to walk into every single strikes.
 	var/strikerange = 7 // how many tiles the strike can reach
 	var/damage = 65
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/thunderstrike/cast(list/targets, mob/user = usr)
 	var/turf/T = get_turf(targets[1])

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/counterspell.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/counterspell.dm
@@ -18,6 +18,7 @@
 	glow_color = GLOW_COLOR_ARCANE
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 	overlay_state = "rune2"
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/counterspell/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))

--- a/code/modules/spells/spell_types/wizard/misc/arcane_prison.dm
+++ b/code/modules/spells/spell_types/wizard/misc/arcane_prison.dm
@@ -11,6 +11,7 @@
 	glow_intensity = GLOW_INTENSITY_HIGH
 	wall_type = /obj/structure/forcefield_weak/arcane_prison
 	cost = 2
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/forcewall/arcane_prison/cast(list/targets,mob/user = usr)
 	var/turf/target = get_turf(targets[1])

--- a/code/modules/spells/spell_types/wizard/misc/enchant_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/misc/enchant_weapon.dm
@@ -21,6 +21,7 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	antimagic_allowed = FALSE
+	xp_gain = TRUE
 
 	charging_slowdown = 3
 	cost = 1

--- a/code/modules/spells/spell_types/wizard/misc/forcewall.dm
+++ b/code/modules/spells/spell_types/wizard/misc/forcewall.dm
@@ -24,6 +24,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	var/wall_type = /obj/structure/forcefield_weak
 	cost = 1
+	xp_gain = TRUE
 
 //adapted from forcefields.dm, this needs to be destructible
 /obj/structure/forcefield_weak

--- a/code/modules/spells/spell_types/wizard/misc/greater_forcewall.dm
+++ b/code/modules/spells/spell_types/wizard/misc/greater_forcewall.dm
@@ -9,6 +9,7 @@
 	glow_intensity = GLOW_INTENSITY_HIGH
 	wall_type = /obj/structure/forcefield_weak
 	cost = 2
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/forcewall/greater/cast(list/targets,mob/user = usr)
 	var/turf/front = get_turf(targets[1])

--- a/code/modules/spells/spell_types/wizard/misc/magicians_brick.dm
+++ b/code/modules/spells/spell_types/wizard/misc/magicians_brick.dm
@@ -21,6 +21,7 @@
 
 	glow_color = GLOW_COLOR_ARCANE
 	glow_intensity = GLOW_INTENSITY_LOW
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/self/magicians_brick/cast(list/targets, mob/living/user = usr)
 	var/obj/item/rogueweapon/R = new /obj/item/rogueweapon/magicbrick(user.drop_location())

--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcane_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcane_bolt.dm
@@ -24,6 +24,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 2
+	xp_gain = TRUE
 
 /obj/projectile/energy/rogue3
 	name = "Arcane Bolt"

--- a/code/modules/spells/spell_types/wizard/projectiles_single/guided_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/guided_bolt.dm
@@ -23,6 +23,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 1
+	xp_gain = TRUE
 
 /obj/projectile/energy/guided_bolt
 	name = "Guided Bolt"

--- a/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
@@ -23,6 +23,7 @@
 	chargedloop = /datum/looping_sound/invokefire
 	associated_skill = /datum/skill/magic/arcane
 	cost = 1
+	xp_gain = TRUE
 
 /obj/projectile/magic/aoe/fireball/rogue2
 	name = "spitfire"

--- a/code/modules/spells/spell_types/wizard/utility/create_campfire.dm
+++ b/code/modules/spells/spell_types/wizard/utility/create_campfire.dm
@@ -24,6 +24,7 @@
 	invocation_type = "shout"
 	glow_color = GLOW_COLOR_FIRE
 	glow_intensity = GLOW_INTENSITY_LOW
+	xp_gain = TRUE
 
 	var/fire_type = /obj/machinery/light/rogue/campfire/create_campfire
 

--- a/code/modules/spells/spell_types/wizard/utility/light.dm
+++ b/code/modules/spells/spell_types/wizard/utility/light.dm
@@ -14,6 +14,7 @@
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
 	cost = 1
 	miracle = FALSE
+	xp_gain = TRUE
 
 	invocation = "Fiat lux."
 	invocation_type = "whisper" //can be none, whisper, emote and shout


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

- Feather Fall cast time reduced from 10 seconds to 5 seconds (still pretty high, but more in line to what their stamina spends)

- Scholar Noble now gets t2 spells. They still have a limited spellcasting pool.

- Artificer and Janitor now have a simulated Arcane Potential virtue, they no longer are t1 casters so they cant get theorical t2 spells if they took Arcane potential, but they do start with 2 spell points now.

- Darvision, Enlarge, Leap, Feather Fall, Non Detection, Conjure Armor & Weapon, thunderstrike, Arcane Prison, Counterspell, Enchant Weapon, Forcewall, Greater Forcewall, Magician Brick, create campfire, Arcane bolt, Guiding Bolt, Spitfire, and Light now properly give xp when casted. Lesser knock and prestidigitation do not, apologies.


## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

it worked.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->

Feather fall still has a long cast time that its not easy to do when on a chase, but its no longer a time that makes it so unusable.

Scholar noble now feels more like a noble that was actually a mage apprentice, but entered the place because of their connections and not talent. They still have 3 points plus message and guiding bolt, which goes on par with an apprentice.

Artificer and Janitor were in a weird spot where they needed prestidigitation but could with arcane potential, get to tier 2. They are now a firm T1 class that will never progress beyond that, but it does let them build Scoms and any arcane thing we might do in the future. 

More spells that give xp makes for a consistent game experience, particularly a lot of T1 spells now give exp as expected, which should make taking t1 spells less of a punishing choice.
