### PR TITLE
Maps in ration papers for the tavern and merchant

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -135,6 +135,22 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "acV" = (
 /obj/structure/closet/crate/chest/old_crate,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "ada" = (
@@ -22002,6 +22018,14 @@
 	dir = 1;
 	icon_state = "longtable_mid"
 	},
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "hQP" = (
@@ -61823,6 +61847,14 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
+/obj/item/ration,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
 "wfk" = (


### PR DESCRIPTION
## About The Pull Request
Adds thirty two (32) ration papers to the map, with eight (8) given to the merchant; and twenty four (24) to the kitchen.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/9438f320-c05f-42f1-b0f2-1851fb9d8c33)

![image](https://github.com/user-attachments/assets/fbd2e9f9-b173-45a9-94fe-c76981e49b53)
![image](https://github.com/user-attachments/assets/71341ffe-4d30-414e-99a2-9847504a2f43)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Making sure that people actually know that we do in fact have greasy ration wrapping paper to make their food unable to rot.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
