### PR TITLE
Alchemical Vials in-bag resize

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
@@ -20,7 +20,8 @@
 	experimental_onhip = FALSE
 	experimental_inhand = FALSE
 	sellprice = 1
-
+	grid_height = 32
+	grid_width = 32
 
 /*
 	The next two functions are copies from ..(), but edited to give the max per transfer.


### PR DESCRIPTION
## About The Pull Request

Let's be honest it never really made sense that the itty-bitty alchemical vials took up the same space as a normal glass bottle. So I fixed that. Wheee.

/obj/item/reagent_containers/glass/alchemical in alch_items.dm didn't actually have a part to define the gridsize it took up, and I'm assuming it was just on assumption pulling from the glass bottles gridsize (2 tall 1 wide). This is just me adding grid_height = 32 grid_width = 32 to it.

Tested to work when both empty and filled, maintains the size.

**Potential Concerns;**

Since this is making alchemical vials that holds 9oz per take up less space than the normal glass bottle, you CAN argue that this would allow people to stock up more volume of reagents in their storage since a glass bottle holds 16oz. Two vials taking up the same space as a glass bottle will hold 9oz x 2 = 18oz. 2oz difference - really not THAT much at all but it's worth highlighting for balance. I don't believe it will create any outright balancing issues though feedback is encouraged if this becomes evident!

(EDIT; nevermind this is actioned on with https://github.com/NovaSector/Solaris/pull/201, glass bottles will be exact double of vials)

## Testing Evidence

![image](https://github.com/user-attachments/assets/583b918e-eb6f-4aa5-9ad4-9e58803f1327)
![image](https://github.com/user-attachments/assets/dde858c3-9471-4e35-a211-53e228fa4ab3)


## Why It's Good For The Game

Small object with small volume size should be actually small in bag :nod:
