### PR TITLE
Increases Glass Bottles capacity to 18oz (2oz increase)

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -8,7 +8,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 	icon_state = "clear_bottle1"
 	amount_per_transfer_from_this = 6
 	possible_transfer_amounts = list(6)
-	volume = 48
+	volume = 54
 	fill_icon_thresholds = list(0, 25, 50, 75, 100)
 	dropshrink = 0.8
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH
@@ -57,7 +57,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 /obj/item/reagent_containers/glass/bottle/proc/shatter(turf/T)
 	if(istransparentturf(T))
 		shatter(GET_TURF_BELOW(T))
-		return 
+		return
 	new /obj/item/natural/glass/shard(get_turf(T))
 	new /obj/effect/decal/cleanable/glass(get_turf(T))
 	qdel(src)

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
@@ -20,7 +20,8 @@
 	experimental_onhip = FALSE
 	experimental_inhand = FALSE
 	sellprice = 1
-
+	grid_height = 32
+	grid_width = 32
 
 /*
 	The next two functions are copies from ..(), but edited to give the max per transfer.


### PR DESCRIPTION
## About The Pull Request

As title describes - really I should have put this with the other PR I just did (https://github.com/NovaSector/Solaris/pull/199) but idk how to use Github Desktop well enough yet sorry LOL

On suggestion and discussion with @OrbisAnima, upped the Glass Bottles capacity to be 2oz more, so totalling 18oz instead of the previous 16oz. This makes glass bottles double what an alchemical vial can hold so it all makes sense now!

Doesn't affect mapgen pre-filled bottles negatively if at all. 

## Testing Evidence

Showing that the bottle now holds 18oz in total (filling the rest of a mapgen bottle with water)
![image](https://github.com/user-attachments/assets/5e42243c-e40c-4bd3-a65a-3222f4ecc048)
![image](https://github.com/user-attachments/assets/1d3a52b6-47f5-420d-a16a-4ef74a5aeed7)

## Why It's Good For The Game

be gentle i'm baby coder
