### PR TITLE
[QoL] Alchemist QoL and Squire fix values buff

### DIFF
--- a/code/game/objects/items/rogueitems/waterskin.dm
+++ b/code/game/objects/items/rogueitems/waterskin.dm
@@ -9,7 +9,7 @@
 	sellprice = 5
 	closed = FALSE
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK
-	obj_flags = CAN_BE_HIT
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	reagent_flags = OPENCONTAINER
 	w_class =  WEIGHT_CLASS_NORMAL
 	drinksounds = list('sound/items/drink_bottle (1).ogg','sound/items/drink_bottle (2).ogg')

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -294,6 +294,8 @@
 					user.visible_message(span_notice("[user] finds [B] in [src]."))
 					return
 			user.visible_message(span_warning("[user] searches through [src]."))
+			if((looty.len) && do_after(user, CLICK_CD_MELEE))
+				attack_hand(user)
 #ifdef MATURESERVER
 			if(!looty.len)
 				to_chat(user, span_warning("Picked clean."))

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 	fill_icon_thresholds = list(0, 25, 50, 75, 100)
 	dropshrink = 0.8
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH
-	obj_flags = CAN_BE_HIT
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	spillable = FALSE
 	var/closed = TRUE
 	reagent_flags = TRANSPARENT

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
@@ -9,7 +9,7 @@
 	fill_icon_thresholds = list(0, 33, 66, 100)
 	dropshrink = 0.8
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH
-	obj_flags = CAN_BE_HIT
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	spillable = FALSE
 	var/closed = TRUE //Put a cork in it!
 	reagent_flags = TRANSPARENT

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -72,7 +72,7 @@
 
 		if(blacksmith_mind.get_skill_level(attacked_item.anvilrepair) <= 0)
 			if(HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) && locate(/obj/machinery/anvil) in attacked_object.loc)
-				repair_percent = 0.035
+				repair_percent = 0.1
 			else if(prob(30))
 				repair_percent = 0.1
 			else


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

- Makes Bushes auto farm until you get an item or its empty.

- Allows for alchemical bottles, regular bottles and waterskins to be renamed with a feather

- Buffs the fixing of Squires to be the same as if they had the required skill.

- Known bug that requires refactor: bottles will change their description if they dont have the fancy bottle tag upon removal and add of corks.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

![image](https://github.com/user-attachments/assets/b3863529-e180-470e-9f74-a6c0b89d264c)

![image](https://github.com/user-attachments/assets/6cb5ebfd-93be-43ff-87d7-81ebe0903022)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->

Makes the bushes less of an annoyance and put them with similar chores (repairing, cooking, crafting, etc), so easy QoL

Allows for Bottles to be tagged, so it makes a lot of people life easier
