### PR TITLE
You can quickly bundle cured leather and sticks. Bags no longer become blocked when dumping things into barrels and presses. Salvaged clothing is now 1 by default. Shovels, fibers and ration papers can be bought at the Merchant. 

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -18124,6 +18124,8 @@
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
 /obj/item/reagent_containers/glass/bucket,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel/small,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
 "gvs" = (

--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -96,6 +96,30 @@
 	sellprice = 7
 	bundletype = /obj/item/natural/bundle/curred_hide
 
+/obj/item/natural/hide/cured/attack_right(mob/user)
+	var/is_legendary = FALSE
+	if(user.mind.get_skill_level(/datum/skill/craft/tanning) == SKILL_LEVEL_LEGENDARY) //check if the user has legendary farming skill
+		is_legendary = TRUE //they do
+	var/work_time = 1 SECONDS //time to gather fibers
+	if(is_legendary)
+		work_time = 2 //if legendary skill, the move_after is fast, 0.2 seconds
+	to_chat(user, span_warning("I start to collect [src]..."))
+	if(move_after(user, work_time, target = src))
+		var/cured_hidecount = 0
+		for(var/obj/item/natural/hide/cured/F in get_turf(src))
+			cured_hidecount++
+		while(cured_hidecount > 0)
+			if(cured_hidecount == 1)
+				new /obj/item/natural/hide/cured(get_turf(user))
+				cured_hidecount--
+			else if(cured_hidecount >= 2)
+				var/obj/item/natural/bundle/curred_hide/B = new(get_turf(user))
+				B.amount = clamp(cured_hidecount, 2, 10)
+				B.update_bundle()
+				cured_hidecount -= clamp(cured_hidecount, 2, 10)
+		for(var/obj/item/natural/hide/cured/F in get_turf(src))
+			qdel(F)
+
 /obj/item/natural/bundle/curred_hide
 	name = "bundle of cured leather"
 	desc = "A bunch of cured leather pieces bundled together."

--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -110,7 +110,7 @@
 			qdel(src)
 			if (L.alpha == 0 && L.rogue_sneaking) // not anymore you're not
 				L.update_sneak_invis(TRUE)
-			if(!HAS_TRAIT(L, TRAIT_WOODWALKER))	
+			if(!HAS_TRAIT(L, TRAIT_WOODWALKER))
 				L.consider_ambush()
 
 /obj/item/grown/log/tree/stick/Initialize()
@@ -154,6 +154,30 @@
 			else
 				to_chat(user, "I can't add any more sticks to the bundle without it falling apart.")
 			return
+
+/obj/item/grown/log/tree/stick/attack_right(mob/user)
+	var/is_legendary = FALSE
+	if(user.mind.get_skill_level(/datum/skill/labor/lumberjacking) == SKILL_LEVEL_LEGENDARY) //check if the user has legendary farming skill
+		is_legendary = TRUE //they do
+	var/work_time = 1 SECONDS //time to gather fibers
+	if(is_legendary)
+		work_time = 2 //if legendary skill, the move_after is fast, 0.2 seconds
+	to_chat(user, span_warning("I start to collect [src]..."))
+	if(move_after(user, work_time, target = src))
+		var/stickcount = 0
+		for(var/obj/item/grown/log/tree/stick/F in get_turf(src))
+			stickcount++
+		while(stickcount > 0)
+			if(stickcount == 1)
+				new /obj/item/grown/log/tree/stick(get_turf(user))
+				stickcount--
+			else if(stickcount >= 2)
+				var/obj/item/natural/bundle/stick/B = new(get_turf(user))
+				B.amount = clamp(stickcount, 2, 10)
+				B.update_bundle()
+				stickcount -= clamp(stickcount, 2, 10)
+		for(var/obj/item/grown/log/tree/stick/F in get_turf(src))
+			qdel(F)
 
 /obj/item/grown/log/tree/stake
 	name = "stake"

--- a/code/modules/cargo/packsrogue/food.dm
+++ b/code/modules/cargo/packsrogue/food.dm
@@ -39,6 +39,14 @@
 					/obj/item/reagent_containers/glass/bottle/rogue/wine,
 				)
 
+/datum/supply_pack/rogue/food/rationpaper
+	name = "Ration Papers"
+	cost = 30
+	contains = list(
+					/obj/item/ration,
+					/obj/item/ration,
+				)
+
 /datum/supply_pack/rogue/food/meat
 	name = "Hardtack"
 	cost = 15

--- a/code/modules/cargo/packsrogue/rawmat.dm
+++ b/code/modules/cargo/packsrogue/rawmat.dm
@@ -47,6 +47,18 @@
 	cost = 125
 	contains = list(/obj/item/rogueore/silver)
 
+/datum/supply_pack/rogue/rawmats/fiber
+	name = "Fiber"
+	cost = 35
+	contains = list(/obj/item/natural/fibers,
+	/obj/item/natural/fibers,
+	/obj/item/natural/fibers,
+	/obj/item/natural/fibers,
+	/obj/item/natural/fibers,
+	/obj/item/natural/fibers,
+	/obj/item/natural/fibers,
+	/obj/item/natural/fibers)
+
 /datum/supply_pack/rogue/rawmats/cloth
 	name = "Cloth"
 	cost = 60

--- a/code/modules/cargo/packsrogue/tools.dm
+++ b/code/modules/cargo/packsrogue/tools.dm
@@ -173,6 +173,16 @@
 	cost = 10
 	contains = list(/obj/item/rogueweapon/pitchfork,)
 
+/datum/supply_pack/rogue/tools/spade
+	name = "Wooden spade"
+	cost = 5
+	contains = list(/obj/item/rogueweapon/shovel/small)
+
+/datum/supply_pack/rogue/tools/shovel
+	name = "Shovel"
+	cost = 20 //That's a 21 force weapon, shovels are no joke.
+	contains = list(/obj/item/rogueweapon/shovel)
+
 /datum/supply_pack/rogue/tools/plough
 	name = "Plough"
 	cost = 50

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -37,7 +37,7 @@
 	var/clothing_flags = NONE
 
 	salvage_result = /obj/item/natural/cloth
-	salvage_amount = 2
+	salvage_amount = 1
 	fiber_salvage = TRUE
 
 	var/toggle_icon_state = TRUE //appends _t to our icon state when toggled

--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -19,6 +19,7 @@
 	l_sleeve_status = SLEEVE_NORMAL
 	flags_inv = HIDECROTCH
 	experimental_inhand = FALSE
+	salvage_amount = 2
 
 /obj/item/clothing/under/roguetown/AdjustClothes(mob/user)
 #ifdef MATURESERVER

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -15,6 +15,7 @@
 	sewrepair = TRUE
 	flags_inv = HIDEBOOB
 	experimental_inhand = FALSE
+	salvage_amount = 2
 
 	grid_width = 64
 	grid_height = 64

--- a/code/modules/farming/brewers_press.dm
+++ b/code/modules/farming/brewers_press.dm
@@ -27,11 +27,11 @@
 
 /obj/structure/brewers_press/attackby(obj/item/I, mob/user, params)
 	if(istype(I,/obj/item/storage/roguebag) && I.contents.len)
-		var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+		var/datum/component/storage/STR = I.GetComponent(/datum/component/storage)
 		for(var/obj/item/reagent_containers/food/snacks/grown/bagged_fruit in I.contents)
 			//If you can press it, transfer the fruit from the bag to the press' storage
 			if(bagged_fruit.can_press)
-				STR.remove_from_storage(bagged_fruit, get_turf(user))
+				STR.remove_from_storage(bagged_fruit, src)
 				if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_INSERT, bagged_fruit, null, TRUE, TRUE))
 					bagged_fruit.inventory_flip(null, TRUE)
 					if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_INSERT, bagged_fruit, null, TRUE, TRUE))
@@ -50,7 +50,7 @@
 				to_chat(user, span_warning("I can't press [honeyitem] in [src]."))
 				return FALSE
 		to_chat(user, span_info("I dump the contents of [I] into [src]."))
-		I.update_icon()	
+		I.update_icon()
 		return TRUE
 	if(user.used_intent)
 		if(user.used_intent.type in list(/datum/intent/fill,/datum/intent/pour,/datum/intent/splash))
@@ -92,7 +92,7 @@
 			food.reagents.remove_reagent(/datum/reagent/water, food.reagents.total_volume)
 		if(food.press_reagent)
 			reagents.add_reagent(food.press_reagent, food.press_amt)
-		
+
 	qdel(food)
 	playsound(src, "bubbles", 100, TRUE)
 	return TRUE

--- a/code/modules/farming/fermenting_barrel.dm
+++ b/code/modules/farming/fermenting_barrel.dm
@@ -51,6 +51,7 @@
 		for(var/obj/item/reagent_containers/food/snacks/bagged_fruit in I.contents)
 			if(try_ferment(bagged_fruit, user, TRUE))
 				success = TRUE
+				I.grid_remove_item(bagged_fruit)
 		if(success)
 			to_chat(user, span_info("I dump the contents of [I] into [src]."))
 			I.update_icon()

--- a/code/modules/farming/fermenting_barrel.dm
+++ b/code/modules/farming/fermenting_barrel.dm
@@ -47,32 +47,38 @@
 		playsound(src, "bubbles", 100, TRUE)
 		return TRUE
 	if(istype(I,/obj/item/storage/roguebag) && I.contents.len)
-		var/success
-		for(var/obj/item/reagent_containers/food/snacks/bagged_fruit in I.contents)
-			if(try_ferment(bagged_fruit, user, TRUE))
-				success = TRUE
-				I.grid_remove_item(bagged_fruit)
-		if(success)
-			to_chat(user, span_info("I dump the contents of [I] into [src]."))
-			I.update_icon()
-		else
-			to_chat(user, span_warning("There's nothing in [I] that I can ferment."))
-		return TRUE
+		var/obj/item/storage/roguebag/baggie = I
+		var/success = try_ferment_roguebag(baggie, user)
+		return success
 	..()
 
-/obj/structure/fermenting_barrel/proc/try_ferment(obj/item/reagent_containers/food/snacks/fruit, mob/user, batch_process)
+/obj/structure/fermenting_barrel/proc/try_ferment(obj/item/reagent_containers/food/snacks/grown/fruit, mob/user)
 	if(!fruit.can_distill)
-		if(!batch_process)
-			to_chat(user, span_warning("I can't ferment this into anything."))
+		to_chat(user, span_warning("I can't ferment this into anything."))
 		return FALSE
 	else if(!user.transferItemToLoc(fruit,src))
-		if(!batch_process)
-			to_chat(user, span_warning("[fruit] is stuck to my hand!"))
+		to_chat(user, span_warning("[fruit] is stuck to my hand!"))
 		return FALSE
-	if(!batch_process)
-		to_chat(user, span_info("I place [fruit] into [src]."))
+	to_chat(user, span_info("I place [fruit] into [src]."))
 	addtimer(CALLBACK(src, PROC_REF(makeWine), fruit), rand(1 MINUTES, 3 MINUTES))
 	return TRUE
+
+/obj/structure/fermenting_barrel/proc/try_ferment_roguebag(obj/item/storage/roguebag/baggie, mob/user)
+	var/success = FALSE
+	var/datum/component/storage/STR = baggie.GetComponent(/datum/component/storage)
+	if(!STR)
+		return FALSE
+	for(var/obj/item/reagent_containers/food/snacks/grown/bagged_fruit in baggie.contents)
+		if(bagged_fruit.can_distill)
+			success = TRUE
+			STR.remove_from_storage(bagged_fruit, src)
+			addtimer(CALLBACK(src, PROC_REF(makeWine), bagged_fruit), rand(1 MINUTES, 3 MINUTES))
+	if(success)
+		to_chat(user, span_info("I dump the fermentable contents of [baggie] into [src]."))
+		return TRUE
+	else
+		to_chat(user, span_warning("There's nothing in [baggie] that I can ferment."))
+		return FALSE
 
 //obj/structure/fermenting_barrel/attack_hand(mob/user)
 //	open = !open


### PR DESCRIPTION
## About The Pull Request

Melting pot of various fixes and QoL changes.

- Did you know if you right click a fiber, silk or cloth piece, you will attempt to bundle EVERY respective item on a tile and move it to yours? This is much more easier than the bundle scoop. Well turns out sticks and cured leather didn't have this feature. It now has.
- Bags should no longer become blocked when trying to fill a barrel or a fermenting press with goods. The reason of such bug is the Tetris inventory. While the items are indeed moved, the Tetris grid thinks that the storage still contained the items. Now it is properly cleaned. Credits to this PR that has found the fix : https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2196
- In terms of gardening tools, you can now buy spades and shovels at the Merchant. The Shovel is of course more expensive than the spade. 
- With the suggestion of @Stalkeros2, Merchants can also sell ration papers for a high price in case no cook can do it. (Likely the price will be adjusted depending at how often these rations are used)
- You can buy some fibers at the merchant too. Should be more expensive than the storage altough, but barely cheaper than the remote storage. If the merchant can import cloth and other ores, I think it is fair that you can also buy fibers in case (sometimes they even spawn in the chest in the export floor anyway). It is also more expensive than the cloth import.
- By default, salvaging clothing pieces will only yield 1 material instead of 2. Exceptions for pants and shirts who are defaulted to 2, and other items who manually set their yield. 

## Testing Evidence
Bags fixed : https://streamable.com/b7s962

Quickly bundling sticks and cured leather, as opposed to the typical bundling before : https://streamable.com/k2c1uc

Salvage results : https://streamable.com/iexkxp

Shovel and Spade in  the shop. Ration papers too. : 
![image](https://github.com/user-attachments/assets/df8f4af8-ea81-4930-b31a-4ae5c8e28f4d)
![image](https://github.com/user-attachments/assets/a6b8f511-609a-4db0-933f-a1790eb7ed0a)

## Why It's Good For The Game

- I wish I knew the easy bundling feature. It makes it easier to filter piles of materials. So I added the same for sticks and twigs, so you can easily pile specific materials into your tile without too much effort. Or clean away the twigs on a freshly cut tree so you can only gather the logs.
- As a Soilson who loves making alcohol, having your bags becoming unusable after dumping all of your apples inside a barrel was annoying. This is fixed.
- Another alternative to buy paper rations in case there is no cook.
- For some reason I thought you could turn cloth into fibers. For a price, you can get the fibers directly delivered in case someone needs fibers.
- So. Turns out, a lot of recipes (specially gloves and boots) only need 1 material to craft, but as  they do not change the salvage yield, you can dupe your materials. The example in mind is the heavy gloves made from 1 fur only, and once salvaged will yield 2. Basically, duping fur. If someone thinks an item should yield more when salvaged, they are welcome to manually set the amount. I made that shirts and pants yield 2 pieces of salvage by default, because their sleeves can be torn for cloth too. And once you remove both sleeves, it yields nothing anymore.
