### PR TITLE
[FIX] Two familiar bugfix.

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/find_familiar.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/find_familiar.dm
@@ -192,8 +192,10 @@
 		var/mob/living/simple_animal/pet/familiar/fam = new familiar_type(spawn_turf)
 		fam.familiar_summoner = user
 		user.visible_message(span_notice("[fam.summoning_emote]"))
-		fam.fully_replace_character_name(null, "[user]'s familiar")
+		fam.fully_replace_character_name(null, "[user.real_name]'s familiar")
 		user.apply_status_effect(fam.buff_given)
+		for (var/faction_to_add in user.faction) //Should stop necromancer's skellies from murdering the necromancer's pet.
+			fam.faction |= faction_to_add
 		log_game("[key_name(user)] summoned non-sentient familiar of type [familiar_type]")
 		user.busy_summoning_familiar = FALSE
 		return TRUE
@@ -340,6 +342,9 @@
 	awakener.stop_automated_movement = TRUE
 	awakener.stop_automated_movement_when_pulled = TRUE
 	awakener.wander = FALSE
+
+	for (var/faction_to_add in user.mind.summons_additional_factions) //Should stop necromancer's skellies from murdering the necromancer's pet.
+		awakener.faction |= faction_to_add
 
 	// Admin/game logging
 	log_game("[key_name(user)] has summoned [key_name(chosen_one)] as familiar '[awakener.name]' ([awakener.type]).")


### PR DESCRIPTION
Necromancer's Familiars don't get killed by their skeletons.

## About The Pull Request
Stops non sentient familiar's names to be set to "Unknown's familiar" when summoned with your face hidden.

Stops Necromancer's skeletons from targeting their master's familiar.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![hooded name](https://github.com/user-attachments/assets/5439eab6-a00a-4dbc-b6f9-4a2552911712)

https://github.com/user-attachments/assets/0927692f-200c-4746-a231-1edbc9b9f9c7

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bug fixing is always goo.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
