### PR TITLE
[Bugfix] Feral eater has immunity to berry based poisons now

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -314,13 +314,14 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 
 /datum/reagent/berrypoison/on_mob_life(mob/living/carbon/M)
-	if(volume > 0.09)
-		if(isdwarf(M))
-			M.add_nausea(1)
-			M.adjustToxLoss(0.5)
-		else
-			M.add_nausea(3) // so one berry or one dose (one clunk of extracted poison, 5u) will make you really sick and a hair away from crit.
-			M.adjustToxLoss(2)
+	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER))	
+		if(volume > 0.09)
+			if(isdwarf(M))
+				M.add_nausea(1)
+				M.adjustToxLoss(0.5)
+			else
+				M.add_nausea(3) // so one berry or one dose (one clunk of extracted poison, 5u) will make you really sick and a hair away from crit.
+				M.adjustToxLoss(2)
 	return ..()
 
 

--- a/modular/Neu_Food/code/drinks/stew.dm
+++ b/modular/Neu_Food/code/drinks/stew.dm
@@ -103,11 +103,12 @@
 
 // Copy pasted from berry poison, but stew metabolizes much faster so it is less deadly. You CAN use it as a source of hydration / nutrition if you are desperate enough???
 /datum/reagent/consumable/soup/stew/berry_poisoned/on_mob_life(mob/living/carbon/M)
-	if(volume > 0.09)
-		if(isdwarf(M))
-			M.add_nausea(1)
-			M.adjustToxLoss(0.5)
-		else
-			M.add_nausea(3) // so one berry or one dose (one clunk of extracted poison, 5u) will make you really sick and a hair away from crit.
-			M.adjustToxLoss(2)
+	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER))
+		if(volume > 0.09)
+			if(isdwarf(M))
+				M.add_nausea(1)
+				M.adjustToxLoss(0.5)
+			else
+				M.add_nausea(3) // so one berry or one dose (one clunk of extracted poison, 5u) will make you really sick and a hair away from crit.
+				M.adjustToxLoss(2)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Two simple checks to the berrypoison reagent, and the poisoned soup reagent.

## Testing Evidence
![List of poisons](https://github.com/user-attachments/assets/8d50beb1-3d04-4d28-b0ce-21b78bc85ea1)
-All the poisons tested- Arrow, raw berry, handpie, pie, stew
![Mmmm bitter](https://github.com/user-attachments/assets/08a788c9-56c6-4776-9abe-fdc45ae1283e)
-All the bitter tastes
![No Toxin! Censored](https://github.com/user-attachments/assets/6d674333-6fc1-4e3c-b37a-9f5e0374fc9f)
-No toxin damage taken from any of them, censored bit is just user id no clue if that's sensitive but better safe than sorry.

## Why It's Good For The Game

Feral eater describes itself as being immune to toxic foods, and as per https://github.com/NovaSector/Solaris/issues/76 that wasn't working. This fix does end up giving the virtue immunity to poison arrows, but considering they apply the same sort of poison that feral eater should be able to eat that's probably not an issue.