### PR TITLE
Revert "Toy Jester Rebalance"

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/toy_jester.dm
+++ b/code/modules/mob/living/carbon/human/npc/toy_jester.dm
@@ -120,58 +120,73 @@ GLOBAL_LIST_INIT(toyjester_aggro, world.file2list("strings/rt/toyjesteraggroline
 	var/toyclass = rand(1,3)
 	switch(toyclass)
 		if(1) //Jester
+			armor = /obj/item/clothing/suit/roguetown/armor/leather
 			shirt = /obj/item/clothing/suit/roguetown/shirt/jester
 			pants = /obj/item/clothing/under/roguetown/tights/jester
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			mask = /obj/item/clothing/mask/rogue/facemask
 			if(prob(50))
 				mask = /obj/item/clothing/mask/rogue/ragmask/black
 			head = /obj/item/clothing/head/roguetown/jester
+			if(prob(50))
+				head = /obj/item/clothing/head/roguetown/helmet/leather
+			neck = /obj/item/clothing/neck/roguetown/leather
+			if(prob(50))
+				neck = /obj/item/clothing/neck/roguetown/gorget
+			gloves = /obj/item/clothing/gloves/roguetown/angle
 			shoes = /obj/item/clothing/shoes/roguetown/jester
-			H.STASTR = rand(12,16)
-			H.STASPD = rand(10,16)
-			H.STACON = rand(12,16)
-			H.STAEND = rand(12,16)
-			H.STAPER = rand(10,16)
-			H.STAINT = rand(8,10)
+			H.STASTR = rand(8,20)
+			H.STASPD = rand(16,18)
+			H.STACON = rand(16,18)
+			H.STAEND = rand(14,16)
+			H.STAPER = rand(12,14)
+			H.STAINT = rand(12,14)
 			if(prob(50))
 				r_hand = /obj/item/rogueweapon/knuckles/bronzeknuckles
 				l_hand = /obj/item/rogueweapon/knuckles/bronzeknuckles
 			else
 				r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
 		if(2) //Toy Arquebusier
+			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 			shirt = /obj/item/clothing/suit/roguetown/shirt/jester
 			pants = /obj/item/clothing/under/roguetown/tights/jester
 			cloak = /obj/item/clothing/cloak/cape
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			mask = /obj/item/clothing/mask/rogue/facemask
 			if(prob(50))
 				mask = /obj/item/clothing/mask/rogue/ragmask/black
 			head = /obj/item/clothing/head/roguetown/helmet/tricorn
 			if(prob(1))
 				head = /obj/item/clothing/head/roguetown/helmet/tricorn/lucky
+			neck = /obj/item/clothing/neck/roguetown/leather
+			if(prob(50))
+				neck = /obj/item/clothing/neck/roguetown/gorget
+			gloves = /obj/item/clothing/gloves/roguetown/angle
 			shoes = /obj/item/clothing/shoes/roguetown/jester
-			H.STASTR = rand(12,16)
-			H.STASPD = rand(10,16)
-			H.STACON = rand(12,16)
-			H.STAEND = rand(12,16)
-			H.STAPER = rand(10,16)
-			H.STAINT = rand(8,10)
+			H.STASTR = rand(15,17)
+			H.STASPD = rand(15,17)
+			H.STACON = rand(16,18)
+			H.STAEND = rand(14,16)
+			H.STAPER = rand(16,18)
+			H.STAINT = rand(12,13)
 			r_hand = /obj/item/rogueweapon/halberd/toyarquebus
+			beltl = /obj/item/ammopouch/bullets
 		if(3) //Toy Knight
+			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
 			shirt = /obj/item/clothing/suit/roguetown/shirt/jester
-			pants = /obj/item/clothing/under/roguetown/tights/jester
+			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			mask = /obj/item/clothing/mask/rogue/facemask
-			if(prob(50))
-				mask = /obj/item/clothing/mask/rogue/ragmask/black
-			head = /obj/item/clothing/head/roguetown/jester
-			if(prob(50))
-				head = /obj/item/clothing/head/roguetown/helmet/skullcap
+			head = /obj/item/clothing/head/roguetown/helmet/skullcap
+			neck = /obj/item/clothing/neck/roguetown/gorget
+			gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 			shoes = /obj/item/clothing/shoes/roguetown/jester
-			H.STASTR = rand(12,16)
-			H.STASPD = rand(10,16)
-			H.STACON = rand(12,16)
-			H.STAEND = rand(12,16)
-			H.STAPER = rand(10,16)
-			H.STAINT = rand(8,10)
+			H.STASTR = rand(16,18)
+			H.STASPD = rand(16,18)
+			H.STACON = rand(16,18)
+			H.STAEND = rand(14,16)
+			H.STAPER = rand(12,14)
+			H.STAINT = rand(12,14)
 			if(prob(50))
 				r_hand = /obj/item/rogueweapon/sword/iron
 				l_hand = /obj/item/rogueweapon/shield/heater


### PR DESCRIPTION
Reverts NovaSector/Solaris#181

Okay; I'm gonna put my argument hat on. The justification for this PR was that it was a nightmare repair grind no matter what.
Here's the rub; though - now misrepair no longer is an active threat; and people have been mogging this dungeon with 1-2 people verse the intended ~5; especially for the final room. Practice has shown it's easy to land hits but hard to BE hit; which isn't swell for what is; effectively speaking - the easiest-access dungeon in the entire game.
So... let's rebuff it back to what it used to be! Armors returned. Stats rebuffed. The whole nine yards. With the new AI; this should generally make the dungeon more of a threat again; and make it harder to just completely shut it down.

To be blunt; though, this dungeon has been metagamed to hell and back and I'm tired of having to balance around it and those who're spending too much time towing the line. I have a nuclear option in my back pocket; still, and I will use it.