### PR TITLE
[Fix] Arcane Potential Prestidigitation and Minor Spells XP

### DIFF
--- a/code/modules/spells/roguetown/acolyte/kasmidian.dm
+++ b/code/modules/spells/roguetown/acolyte/kasmidian.dm
@@ -28,6 +28,7 @@
 	associated_skill = /datum/skill/misc/music
 	recharge_time = 2 MINUTES
 	range = 7
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/mockery/cast(list/targets, mob/user = usr)
 	playsound(get_turf(user), 'sound/magic/mockery.ogg', 40, FALSE)

--- a/code/modules/spells/roguetown/acolyte/zira.dm
+++ b/code/modules/spells/roguetown/acolyte/zira.dm
@@ -18,6 +18,7 @@
 	antimagic_allowed = TRUE
 	recharge_time = 15 SECONDS
 	cost = 1
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/blindness/miracle
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
@@ -59,6 +60,7 @@
 	antimagic_allowed = TRUE
 	hide_charge_effect = TRUE
 	cost = 2
+	xp_gain = TRUE
 
 /obj/effect/proc_holder/spell/invoked/invisibility/miracle
 	miracle = TRUE

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -5,9 +5,9 @@
 	added_skills = list(list(/datum/skill/magic/arcane, 1, 6))
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
+	if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
+		recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	if (!is_arcane(recipient)) // we can do this because apply_to is always called first
-		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
-			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		ADD_TRAIT(recipient, TRAIT_MAGIC_TALENT, TRAIT_GENERIC)
 		recipient.mind?.adjust_spellpoints(2)
 	else


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Makes Invisibility and Blindness give Arcane xp and they should had.

Makes Vicious Mockery to give Music xp. Its minor compared to what just using the instrument in front of people does, but its consistent and fun.

Makes Arcane Potential give Prestidigitation even if you have the arcane skill, but dont have the prestigiditation spell.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

tested localy

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->

Spells giving XP when they should is consistent. Vicious mockery as explained is more a consistency thing than of real use of the players, performance already levels up incredibly fast and with no stamina expendidure due to just using the instrument in presence of others.

The Arcane potential oversight allow warlock players to get prestidigitation, which helps with things like passing as a mage, RPing, and similar stuff, its just really minor utility.
