### PR TITLE
Conjure Tools Spell

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_tool.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_tool.dm
@@ -1,0 +1,59 @@
+#define CONJURE_DURATION 15 MINUTES
+
+/obj/effect/proc_holder/spell/invoked/conjure_tool
+	name = "Conjure Tool"
+	desc = "Conjure a tool of your choice in your hand or on the ground.\n\
+	The tool lasts for 15 minutes - but will refresh its duration infinitely when in the hand of an Arcane user."
+	overlay_state = "null"
+	sound = list('sound/magic/whiteflame.ogg')
+
+	releasedrain = 60
+	chargedrain = 1
+	chargetime = 3 SECONDS // Tools aren't meant to be used in combat nor are they good for it, so it's a faster charge.
+	no_early_release = TRUE
+	recharge_time = 60 SECONDS // Can't be spammed, but you can get a few tools decently quickly.
+
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	movement_interrupt = TRUE
+	antimagic_allowed = FALSE
+	charging_slowdown = 3
+	cost = 1
+	xp_gain = TRUE
+	spell_tier = 1
+
+	invocation = "Instrumentum Exoriantur!"
+	invocation_type = "shout"
+	glow_color = GLOW_COLOR_METAL
+	glow_intensity = GLOW_INTENSITY_LOW
+
+	var/list/tool_options = list(
+		"Hoe" = /obj/item/rogueweapon/hoe,
+		"Thresher" = /obj/item/rogueweapon/thresher,
+		"Sickle" = /obj/item/rogueweapon/sickle,
+		"Pitchfork" = /obj/item/rogueweapon/pitchfork,
+		"Tongs" = /obj/item/rogueweapon/tongs,
+		"Hammer" = /obj/item/rogueweapon/hammer,
+		"Shovel" = /obj/item/rogueweapon/shovel,
+		"Fishing Rod" = /obj/item/fishingrod,
+	)
+
+/obj/effect/proc_holder/spell/invoked/conjure_tool/cast(list/targets, mob/living/user = usr)
+	var/tool_choice = input(user, "Choose a tool", "Conjure tool") as anything in tool_options
+	if(!tool_choice)
+		return
+	tool_choice = tool_options[tool_choice]
+
+	if (tool_choice == /obj/item/fishingrod)
+		var/obj/item/R = new tool_choice(user.drop_location())
+		R.AddComponent(/datum/component/conjured_item, CONJURE_DURATION)
+		user.put_in_hands(R)
+		return
+	else
+		var/obj/item/rogueweapon/R = new tool_choice(user.drop_location())
+		R.AddComponent(/datum/component/conjured_item, CONJURE_DURATION)
+		user.put_in_hands(R)
+		return TRUE
+
+
+#undef CONJURE_DURATION

--- a/code/modules/spells/spell_types/wizard/spell_list.dm
+++ b/code/modules/spells/spell_types/wizard/spell_list.dm
@@ -42,6 +42,7 @@ GLOBAL_LIST_INIT(learnable_spells, (list(/obj/effect/proc_holder/spell/invoked/p
 		/obj/effect/proc_holder/spell/self/light,
 		/obj/effect/proc_holder/spell/invoked/conjure_weapon,
 		/obj/effect/proc_holder/spell/invoked/conjure_armor,
+		/obj/effect/proc_holder/spell/invoked/conjure_tool,
 		/obj/effect/proc_holder/spell/self/magicians_brick,
 		/obj/effect/proc_holder/spell/invoked/projectile/guided_bolt,
 		/obj/effect/proc_holder/spell/invoked/thunderstrike,

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1906,6 +1906,7 @@
 #include "code\modules\spells\spell_types\wizard\buffs_debuffs\stoneskin.dm"
 #include "code\modules\spells\spell_types\wizard\conjure\celestial_vigil.dm"
 #include "code\modules\spells\spell_types\wizard\conjure\conjure_armor.dm"
+#include "code\modules\spells\spell_types\wizard\conjure\conjure_tool.dm"
 #include "code\modules\spells\spell_types\wizard\conjure\conjure_weapon.dm"
 #include "code\modules\spells\spell_types\wizard\conjure\find_familiar.dm"
 #include "code\modules\spells\spell_types\wizard\conjure\void_vigil.dm"


### PR DESCRIPTION
## About The Pull Request
A spell that lets you conjure tools, pretty self-explanatory.
Tools included: Hoe, sickle, thresher, pitchfork, shovel, tongs, hammer, fishing rod.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/6535a449-dab5-412e-9cb9-1d23c3dd7416)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
You can summon weapons and armor, tools shouldn't be too complex for mages to conjure.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
