### PR TITLE
[Fix] Fixes Spell Overflow & Aethernus Priest double revive

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -241,7 +241,7 @@
 	var/coord_col = "+[col-1]"
 	var/coord_col_offset = 4 + 2 * col
 
-	var/coord_row = "[row ? -row : "+0"]"
+	var/coord_row = "[row ? "+[row]" : "+0"]"
 
 	return "WEST[coord_col]:[coord_col_offset],SOUTH[coord_row]:3"
 

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -15,7 +15,7 @@
 				to keep this as it is, fraught as it may sometimes feel - and your own opinions therein..."
 	whitelist_req = FALSE
 
-	spells = list(/obj/effect/proc_holder/spell/invoked/cure_rot, /obj/effect/proc_holder/spell/invoked/revive, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk)
+	spells = list(/obj/effect/proc_holder/spell/invoked/cure_rot, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk)
 	outfit = /datum/outfit/job/roguetown/priest
 
 	display_order = JDO_PRIEST
@@ -56,7 +56,7 @@
 	ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
 	if(H.mind)
-		H.cmode_music = 'sound/music/combat_holy.ogg' 
+		H.cmode_music = 'sound/music/combat_holy.ogg'
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 5, TRUE)
@@ -77,12 +77,16 @@
 		H.change_stat("speed", -1)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron) // This creates the cleric holder used for devotion spells
 	C.grant_spells_priest(H)
+	if (!H.mind?.has_spell(/obj/effect/proc_holder/spell/invoked/revive)) // If not an aethernus priest, we give them Revive
+		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/revive)
+	else // If aethernus priest, we give them turn undead since we are nice people.
+		if (!H.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/abrogation))
+			H.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/abrogation)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 
 	H.verbs |= /mob/living/carbon/human/proc/coronate_lord
 	H.verbs |= /mob/living/carbon/human/proc/churchexcommunicate
 	H.verbs |= /mob/living/carbon/human/proc/churchannouncement
-//	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)		- You are literally disinherited. Begone......
 
 
 /mob/living/carbon/human/proc/coronate_lord()


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

- Makes new actions be granted on the row above instead below, so it stops breaking the UI when you got enough spells

- Makes it so Aethernus Priests get turn undead instead of Revive twice. (Band aid thing until we redo the faith system)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

![image](https://github.com/user-attachments/assets/35e954e8-383f-4bbb-acfa-1fa425f16817)

![image](https://github.com/user-attachments/assets/bdf2cf77-8c61-4f04-b41e-32f449a88fe3)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->

The UI not breaking is good for my sanity. I understand this is good for others gameplay inmersion but having me not going mad with playing means I keep coding for it. 

The double spell revive really doesnt contribute to anything but the very weird specific use case. Instead I gave them turn undead which I kinda suspect wont happen ever with the priest but its nice for them to have instead of a second spell. I would likely agree with anything else but that was the first pick I took.