### PR TITLE
Removes maneater delimb and decap ability.

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -76,7 +76,7 @@
 				spawn(50)
 					if(C && (C.buckled == src))
 						playsound(src, 'sound/misc/eat.ogg', rand(30,60), TRUE)
-						C.adjustBruteLoss(35)
+						C.adjustBruteLoss(30)
 						seednutrition += 20
 						src.visible_message(span_danger("[src] bites down hard on [C]!"))
 						if(C.mind)
@@ -84,7 +84,7 @@
 						return
 			else
 				src.visible_message(span_danger("[src] starts to rip apart [L]!"))
-				L.adjustBruteLoss(20)
+				L.adjustBruteLoss(45)
 				seednutrition += 20
 				if(L.mind)
 					maneater_spit_out(L)

--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -75,41 +75,20 @@
 				src.visible_message(span_danger("[src] starts to rip apart [C]!"))
 				spawn(50)
 					if(C && (C.buckled == src))
-						var/obj/item/bodypart/limb
-						var/list/limb_list = list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-						for(var/zone in limb_list)
-							limb = C.get_bodypart(zone)
-							if(limb)
-								playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
-								limb.dismember()
-								qdel(limb)
-								seednutrition += 20
-								if(C.mind) // eat only one limb of things with minds
-									maneater_spit_out(C)
-									return
-								return
-						if(C.mind) // nugget case, just spit them out
+						playsound(src, 'sound/misc/eat.ogg', rand(30,60), TRUE)
+						C.adjustBruteLoss(35)
+						seednutrition += 20
+						src.visible_message(span_danger("[src] bites down hard on [C]!"))
+						if(C.mind)
 							maneater_spit_out(C)
-							return
-						limb = C.get_bodypart(BODY_ZONE_HEAD)
-						if(limb)
-							playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
-							limb.dismember()
-							qdel(limb)
-							return
-						limb = C.get_bodypart(BODY_ZONE_CHEST)
-						if(limb)
-							if(!limb.dismember())
-								C.gib()
-								seednutrition += 50
-							return
+						return
 			else
 				src.visible_message(span_danger("[src] starts to rip apart [L]!"))
-				spawn(50)
-					if(L && (L.buckled == src))
-						L.gib()
-						seednutrition += 30
-						return
+				L.adjustBruteLoss(20)
+				seednutrition += 20
+				if(L.mind)
+					maneater_spit_out(L)
+				return
 
 /obj/structure/flora/roguegrass/maneater/real/proc/maneater_spit_out(mob/living/C)
 	if(!C)


### PR DESCRIPTION


## About The Pull Request

Maneaters are no longer able to delimb or decap players or mobs. Instead you take brute damage from being atop of them.

## Testing Evidence

Compiled and tested locally, now they just just do straight brute damage.

## Why It's Good For The Game

Having maneaters able to rip off limbs and a head in a single bite is bad, especially when it like other mobs have the capacity to delete the limb entirely is bad.  For a very simple mob, and given all the other actual dangers that can do this to players it seems rather excessive, especially when they are at times hard to spot being behind trees, bushes, and other parts of the scenery.  It will hurt, but it will not kill.  This should make something that should be more of a mild element not debilitating.
