### PR TITLE
We Forest Knights Now

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -332,7 +332,7 @@
 
 /obj/item/clothing/suit/roguetown/armor/leather/hide/warden
 	name = "forestry armor"
-	desc = "A light armor worn by the Wardens of Rasura. Far more durable than leather."
+	desc = "The standard issue light armor of Wardens of Rasura. While often forgone for personal preferences, the Forestry Armor offers a reasonable trade-off between mobility and protection against the various fauna and kith of the wilds. Far more durable than leather"
 	icon = 'icons/roguetown/clothing/special/warden.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/warden.dmi'
 	icon_state = "foresthide"

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -332,7 +332,7 @@
 
 /obj/item/clothing/suit/roguetown/armor/leather/hide/warden
 	name = "forestry armor"
-	desc = "The standard issue light armor of Wardens of Rasura. While often forgone for personal preferences, the Forestry Armor offers a reasonable trade-off between mobility and protection against the various fauna and kith of the wilds. Far more durable than leather"
+	desc = "The standard issue light armor of Wardens of Rasura. While often forgone for personal preferences, the Forestry Armor offers a reasonable trade-off between mobility and protection against the various fauna and kith of the wilds. Far more durable than leather."
 	icon = 'icons/roguetown/clothing/special/warden.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/warden.dmi'
 	icon_state = "foresthide"

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -882,7 +882,7 @@
 
 /obj/item/clothing/cloak/raincloak/furcloak/woad
 	name = "Warden's fur cloak"
-	desc = "The stark blue cloak worn by the Wardens of Rasura. When Old Sunmarch fell, a Warden bearing the flag of the Skymark could be seen leading the charge to find survivors amongst the ruins. The Wardens of Rasura now dye their furs in the old heraldry in remembrance of their sacrifice. Leave the honor for the knights- There is work to be done.
+	desc = "The stark blue cloak worn by the Wardens of Rasura. When Old Sunmarch fell, a Warden bearing the flag of the Skymark could be seen leading the charge to find survivors amongst the ruins. The Wardens of Rasura now dye their furs in the old heraldry in remembrance of their sacrifice. Leave the honor for the knights- There is work to be done."
 	color = "#597fb9"
 
 /obj/item/clothing/head/hooded/rainhood/furhood

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -882,7 +882,7 @@
 
 /obj/item/clothing/cloak/raincloak/furcloak/woad
 	name = "Warden's fur cloak"
-	desc = "Usually sewn by the very wardens that wear them, this hue of blue is made to alart denizens of the forest to their presence."
+	desc = "The stark blue cloak worn by the Wardens of Rasura. When Old Sunmarch fell, a Warden bearing the flag of the Skymark could be seen leading the charge to find survivors amongst the ruins. The Wardens of Rasura now dye their furs in the old heraldry in remembrance of their sacrifice. Leave the honor for the knights- There is work to be done.
 	color = "#597fb9"
 
 /obj/item/clothing/head/hooded/rainhood/furhood

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1805,7 +1805,7 @@
 
 /obj/item/clothing/head/roguetown/helmet/bascinet/antler
 	name = "wardens's helmet"
-	desc = "A strange helmet adorned with antlers worn by the warden of the forest."
+	desc = "The standard issue helmet of the Wardens of Rasura. Despite its flashy appearance and protective structure, many wardens seem to reject this helm in favor of more comfortable options. The regalia never suited them anyways. "
 	icon = 'icons/roguetown/clothing/special/warden.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/warden64.dmi'
 	bloody_icon = 'icons/effects/blood64.dmi'

--- a/code/modules/jobs/job_types/roguetown/keep/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/keep/garrison/bogguard.dm
@@ -104,20 +104,19 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/warden
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/woad
 	neck = /obj/item/clothing/neck/roguetown/coif
-	neck = /obj/item/storage/keyring/guard
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	id = /obj/item/scomstone/bad/garrison
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	beltl = /obj/item/quiver/arrows
+	beltl = /obj/item/storage/keyring/guard
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/rogueweapon/huntingknife/idagger/navaja
+	beltr = /obj/item/quiver/arrows
 	backr = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
 	backl = /obj/item/storage/backpack/rogue/satchel
 	r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging, /obj/item/needle = 1, /obj/item/flashlight/flare/torch/lantern = 1)
+	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging, /obj/item/needle = 1, /obj/item/flashlight/flare/torch/lantern = 1, /obj/item/rogueweapon/huntingknife/idagger/navaja = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE) 
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE) 

--- a/code/modules/jobs/job_types/roguetown/keep/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/keep/garrison/bogguard.dm
@@ -4,7 +4,7 @@
 	department_flag = GARRISON
 	selection_color = JCOLOR_SOLDIER
 	faction = "Station"
-	total_positions = 4
+	total_positions = 6
 	spawn_positions = 4
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
@@ -47,7 +47,7 @@
 	. = ..()
 	head = /obj/item/clothing/head/roguetown/helmet/bascinet/antler
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/warden
-	cloak = /obj/item/clothing/cloak/wardencloak
+	cloak = /obj/item/clothing/cloak/raincloak/furcloak/woad
 	neck = /obj/item/clothing/neck/roguetown/coif
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
@@ -60,7 +60,7 @@
 	beltr = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
 	backr = /obj/item/storage/backpack/rogue/satchel
 	r_hand = /obj/item/rogueweapon/spear
-	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging, /obj/item/flashlight/flare/torch/lantern = 1)
+	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging, /obj/item/needle = 1, /obj/item/flashlight/flare/torch/lantern = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE) //Melee subclass and also garrison cannot have <4 wrestling/unarmed or we default to lethality
@@ -102,7 +102,8 @@
 	. = ..()
 	head = /obj/item/clothing/head/roguetown/helmet/kettle
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/warden
-	cloak = /obj/item/clothing/cloak/wardencloak
+	cloak = /obj/item/clothing/cloak/raincloak/furcloak/woad
+	neck = /obj/item/clothing/neck/roguetown/coif
 	neck = /obj/item/storage/keyring/guard
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
@@ -116,7 +117,7 @@
 	backr = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
 	backl = /obj/item/storage/backpack/rogue/satchel
 	r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging, /obj/item/flashlight/flare/torch/lantern = 1)
+	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging, /obj/item/needle = 1, /obj/item/flashlight/flare/torch/lantern = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE) 
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE) 
@@ -155,19 +156,20 @@
 	. = ..()
 	head = /obj/item/clothing/head/roguetown/helmet/leather/saiga
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/warden
-	cloak = /obj/item/clothing/cloak/wardencloak
-	neck = /obj/item/storage/keyring/guard
+	cloak = /obj/item/clothing/cloak/raincloak/furcloak/woad
+	neck = /obj/item/clothing/neck/roguetown/coif
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	id = /obj/item/scomstone/bad/garrison
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
+	beltl = /obj/item/storage/keyring/guard
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
 	backl = /obj/item/storage/backpack/rogue/satchel
 	l_hand = /obj/item/rogueweapon/shield/wood
-	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging = 1, /obj/item/flashlight/flare/torch/lantern = 1, /obj/item/ritechalk = 1)
+	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging = 1, /obj/item/flashlight/flare/torch/lantern = 1, /obj/item/needle = 1, /obj/item/ritechalk = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE) //Garrison cannot have <4 wrestling or we default to lethality
@@ -207,3 +209,58 @@
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stave_the_dying)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/acidsplash)
 
+//Warden Squire
+/datum/advclass/bogguardsman/sproutling
+	name = "Sproutling"
+	tutorial = "By choice, exile, or just happenstance, you have become an apprentice to the Wardens. While you have not yet earned your woadcloak, you have undergone the old rites to hear the wilds's murmurs. Follow your fellow Wardens into the woad and beyond."
+	outfit = /datum/outfit/job/roguetown/bogguardsman/sproutling
+	category_tags = list(CTAG_WARDEN)
+
+
+/datum/outfit/job/roguetown/bogguardsman/sproutling/pre_equip(mob/living/carbon/human/H)
+	. = ..()
+	head = /obj/item/clothing/head/roguetown/helmet/kettle
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/warden
+	cloak = /obj/item/clothing/cloak/wardencloak //no blue cloak for the apprentice, you gotta earn it.
+	neck = /obj/item/clothing/neck/roguetown/coif
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	id = /obj/item/scomstone/bad/garrison
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	beltl = /obj/item/storage/keyring/guard
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/rogueweapon/hammer
+	backr = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
+	r_hand = /obj/item/rogueweapon/spear
+	backpack_contents = list(/obj/item/rogueweapon/surgery/cautery/purging, /obj/item/flashlight/flare/torch/lantern = 1, /obj/item/needle = 1)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE) //Melee subclass and also garrison cannot have <4 wrestling/unarmed or we default to lethality, in this case it's a squire so 2.
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE) //Axes are a part of the Warden identity.
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE) //Traversal is a necessary part of the warden kit 
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/tanning, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 4, TRUE) //Wardens NEEED tracking to function in finding bodies and outlaws alike 
+		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/labor/farming, 2, TRUE)
+		H.change_stat("strength", 2)
+		H.change_stat("perception", 1)
+		H.change_stat("endurance", 2)
+		H.change_stat("speed", 1)
+		H.verbs |= /mob/proc/haltyell
+	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DEATHSIGHT, TRAIT_GENERIC)	
+	ADD_TRAIT(H, TRAIT_SQUIRE_REPAIR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_WOODSMAN, TRAIT_GENERIC) // Longstrider where active, +3 per, +1 speed
+	ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -133,11 +133,11 @@
 			for (var/mob/living/player in GLOB.player_list)
 				if (player.stat == DEAD || isbrain(player))
 					continue
-					if (HAS_TRAIT(player, TRAIT_DEATHSIGHT))
-						if (HAS_TRAIT(player, TRAIT_WOODSMAN))
-							to_chat(player, span_warning("murmurs on the wind claw my heart towards [locale] for but the faintest of heartbeats."))
-						else
-							to_chat(player, span_warning("Veiled whispers herald Tsoridys' gaze in my mind's eye as it turn towards [locale] for but a brief, singular moment."))
+				if (HAS_TRAIT(player, TRAIT_DEATHSIGHT))
+					if (HAS_TRAIT(player, TRAIT_WOODSMAN))
+						to_chat(player, span_warning("murmurs on the wind claw my heart towards [locale] for but the faintest of heartbeats."))
+					else
+						to_chat(player, span_warning("Veiled whispers herald Tsoridys' gaze in my mind's eye as it turn towards [locale] for but a brief, singular moment."))
 	// AZURE EDIT END
 
 	return TRUE

--- a/code/modules/surgery/surgery_tools_rogue.dm
+++ b/code/modules/surgery/surgery_tools_rogue.dm
@@ -203,7 +203,7 @@
 	throwforce = 16
 	wdefense = 3
 	wbalance = 1
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	thrown_bclass = BCLASS_CHOP
 	tool_behaviour = TOOL_SAW
 	smeltresult = null


### PR DESCRIPTION
## About The Pull Request
Adds a new Warden subclass- Sproutling. It is effectively a Warden squire, meant as a subclass for people who are transitioning a character to warden to be able to have that narrative bit of training before jumping into full Warden responsibilities.

Also adjusts the kit of wardens- mostly patching holes I missed on the previous pass-through. They spawn with needles now, and also all have coifs, as the armor is normalized. Additionally, Full wardens spawn with woadcloaks, not the warden cloaks because tbh they're more evocative, and the blue cloaks have been woven into the lore more directly.

Finally, increases the warden max from 4 to 6. I'm planning on re-adding the northern warden tower back in, so this allows a split of three wardens between north and south. For now, this further allows newer wardens to join the ranks without feeling quite so much pressure. 


## Testing Evidence

![21b03bfc46248a35524cd7c33ad37663](https://github.com/user-attachments/assets/601a19a1-6a10-4074-9381-2ed39538a604)
![d62dca073df70efb5392c9aea2fac8e8](https://github.com/user-attachments/assets/c068f4df-2521-4774-9731-8533ee8ec69b)


## Why It's Good For The Game
The new subclass is in fact a straight downgrade to the other subclasses, and might need a buff later. However, it is a subclass designed to give narrative and mechanical room for someone's character to _become_ a warden. It also allows players to dip their toes into the role generally without feeling forced to know all the ins and outs off rip. 
