### PR TITLE
Port over AP Force String display + Durability display

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -407,6 +407,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(minstr)
 			inspec += "\n<b>MIN.STR:</b> [minstr]"
 
+		if(force)
+			inspec += "\n<b>FORCE:</b> [get_force_string(force)]"
+		if(gripped_intents && !wielded)
+			inspec += "\n<b>WIELDED FORCE:</b> [get_force_string(force_wielded)]"
+
 		if(wbalance)
 			inspec += "\n<b>BALANCE: </b>"
 			if(wbalance < 0)
@@ -469,8 +474,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 		if(max_integrity)
 			inspec += "\n<b>DURABILITY:</b> "
-			var/meme = round(((obj_integrity / max_integrity) * 100), 1)
-			inspec += "[meme]%"
+			var/percent = round(((obj_integrity / max_integrity) * 100), 1)
+			inspec += "[percent]% ([obj_integrity])"
 
 		to_chat(usr, "[inspec.Join()]")
 
@@ -1012,27 +1017,24 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/on_juice()
 
-/obj/item/proc/set_force_string()
+/obj/item/proc/get_force_string(var/force)
 	switch(force)
-		if(0 to 4)
-			force_string = "very low"
-		if(4 to 7)
-			force_string = "low"
-		if(7 to 10)
-			force_string = "medium"
-		if(10 to 11)
-			force_string = "high"
-		if(11 to 20) //12 is the force of a toolbox
-			force_string = "robust"
-		if(20 to 25)
-			force_string = "very robust"
+		if(0 to 9)
+			return "Puny"
+		if(10 to 14)
+			return "Weak"
+		if(15 to 19)
+			return "Modest"
+		if(20 to 24)
+			return "Fine"
+		if(25 to 29)
+			return "Great"
+		if(30 to 35)
+			return "Grand"
 		else
-			force_string = "exceptionally robust"
-	last_force_string_check = force
+			return "Mighty"
 
 /obj/item/proc/openTip(location, control, params, user)
-	if(last_force_string_check != force && !(item_flags & FORCE_STRING_OVERRIDE))
-		set_force_string()
 	if(!(item_flags & FORCE_STRING_OVERRIDE))
 		openToolTip(user,src,params,title = name,content = "[desc]<br>[force ? "<b>Force:</b> [force_string]" : ""]",theme = "")
 	else


### PR DESCRIPTION
## About The Pull Request
Port over 2 PRs I forgot the PR number for from AP. 
- Display the force of weapon as a string 
- Display the durability / integrity of a piece of armor as a string.

If you want the exact number to be displayed I can tweak this PR. If you want strings used for durability I can also do that if someone provide me a list of words - I'm not that good at fancy words

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_LSzgyL1c5F](https://github.com/user-attachments/assets/c2fa9244-e47f-490b-a9f3-07571f538872)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Know yourself and know your enemy, and you will always be victorious.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
