### PR TITLE
Adds far travel tile to Roguetest.

### DIFF
--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -1086,6 +1086,10 @@
 "cX" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/provincial/indoors)
+"mk" = (
+/obj/structure/far_travel,
+/turf/open/floor/rogue/blocks,
+/area/provincial/indoors)
 "qw" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/cobble,
@@ -1096,6 +1100,11 @@
 "vW" = (
 /turf/open/floor/rogue/cobble,
 /area/provincial/indoors/town/steward/import_platform)
+"Jz" = (
+/obj/effect/landmark/latejoin,
+/obj/structure/far_travel,
+/turf/open/floor/rogue/blocks,
+/area/provincial/indoors)
 "QR" = (
 /turf/open/floor/rogue/dirt,
 /area/provincial/outdoors/forest)
@@ -4415,7 +4424,7 @@ bq
 bq
 bq
 bq
-bq
+mk
 ax
 ab
 aa
@@ -4672,7 +4681,7 @@ bH
 bq
 bH
 bq
-bH
+Jz
 ax
 ab
 aa
@@ -4929,7 +4938,7 @@ bq
 bq
 bq
 bq
-bq
+mk
 ax
 ab
 aa
@@ -5186,7 +5195,7 @@ bH
 bq
 bH
 bq
-bH
+Jz
 ax
 ab
 aa


### PR DESCRIPTION
## About The Pull Request
Add four far travel tiles to roguetest to make it easier to exit and check build or something without using the game panel.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_b7kg0f2v0g](https://github.com/user-attachments/assets/2d218737-1248-498c-8692-bc5888262508)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Faster iteration. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't manage it concisely, then it probably isn't good for the game in the first place. -->
