### PR TITLE
Tree Felling Bug Fix

### DIFF
--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -35,16 +35,42 @@
 						user.put_in_hands(I)
 			return
 
-/obj/structure/flora/newtree/obj_destruction(damage_flag)
-	src.obj_flags &= ~BLOCK_Z_OUT_DOWN //so the logs actually fall when pulled by zfall
-	var/turf/my_turf = get_turf(src)
+/obj/structure/flora/newtree/obj_destruction(damage_flag)//this proc is stupidly long for a destruction proc
+	var/turf/NT = get_turf(src)
+	var/turf/UPNT = get_step_multiz(src, UP)
+	src.obj_flags = CAN_BE_HIT | BLOCK_Z_IN_UP //so the logs actually fall when pulled by zfall
 
-	if(!istype(my_turf, /turf/open/transparent/openspace) && !(locate(/obj/structure/flora/roguetree/stump) in my_turf))
-		new /obj/structure/flora/roguetree/stump(my_turf)
+	for(var/obj/structure/flora/newtree/D in UPNT)//theoretically you'd be able to break trees through a floor but no one is building floors under a tree so this is probably fine
+		D.obj_destruction(damage_flag)
+	for(var/obj/item/grown/log/tree/I in UPNT)
+		UPNT.zFall(I)
 
+	for(var/DI in GLOB.cardinals)
+		var/turf/B = get_step(src, DI)
+		for(var/obj/structure/flora/newbranch/BRANCH in B)//i straight up can't use locate here, it does not work
+			if(BRANCH.dir == DI)
+				var/turf/BI = get_step(B, DI)
+				for(var/obj/structure/flora/newbranch/bi in BI)//2 tile end branch
+					if(bi.dir == DI)
+						bi.obj_flags = CAN_BE_HIT
+						bi.obj_destruction(damage_flag)
+					for(var/atom/bio in BI)
+						BI.zFall(bio)
+				for(var/obj/structure/flora/newleaf/bil in BI)//2 tile end leaf
+					bil.obj_destruction(damage_flag)
+				BRANCH.obj_flags = CAN_BE_HIT 
+				BRANCH.obj_destruction(damage_flag)
+			for(var/atom/BRA in B)//unload a sack of rocks on a branch and stand under it, it'll be funny bro
+				B.zFall(BRA)
+
+	for(var/turf/DIA in block(get_step(src, SOUTHWEST), get_step(src, NORTHEAST)))
+		for(var/obj/structure/flora/newleaf/LEAF in DIA)
+			LEAF.obj_destruction(damage_flag)
+
+	if(!istype(NT, /turf/open/transparent/openspace) && !(locate(/obj/structure/flora/roguetree/stump) in NT))//if i don't add the stump check it spawns however many zlevels it goes up because of src recursion
+		new /obj/structure/flora/roguetree/stump(NT)
 	playsound(src, 'sound/misc/treefall.ogg', 100, FALSE)
-
-	return ..()
+	. = ..()
 
 /obj/structure/flora/newtree/attack_hand(mob/user)
 	if(isliving(user))


### PR DESCRIPTION
## About The Pull Request

This pr resolves https://github.com/NovaSector/Solaris/issues/279

The acorn shelter pr optimized newtree/obj_destruction() but introduced a loop-disrupting bug in that you get 1/4th of the amount of wood intended. This PR reverts the obj_destruction() code to the original with, seemingly, no regressions or downsides.

## Testing Evidence

Trees give the intended amount of resources now
![1](https://github.com/user-attachments/assets/3dd70cfb-6199-4e5c-9611-3aca6acf5b9c)

Acorn shelters work the same
![2](https://github.com/user-attachments/assets/6a643b93-b612-4226-8d16-3e4afe002fc8)

## Why It's Good For The Game

This bug was making everyone's life worse immeasurably.
