### PR TITLE
Allows bloodsuckers to gain triumphs and RCP

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -363,6 +363,9 @@
 		return
 	remove_status_effect(/datum/status_effect/debuff/vamp_dreams)
 	mind.sleep_adv.advance_cycle()
+	allmig_reward++
+	adjust_triumphs(1)
+	to_chat(src, span_danger("Days Survived: \Roman[allmig_reward]"))
 
 #undef THERMAL_PROTECTION_HEAD
 #undef THERMAL_PROTECTION_CHEST


### PR DESCRIPTION
## About The Pull Request

Adds proper "nights survived" tracking to the handle_vamp_dreams proc, allowing bloodsuckers to be properly rewarded with triumphs and round contribution points when applicable.

## Testing Evidence

<img width="541" height="357" alt="image" src="https://github.com/user-attachments/assets/ef00a164-df48-4bf0-b810-2ddfbba2ab4f" />

## Why It's Good For The Game

Players in the round, contributing to the round, should get RCP and triumphs consistently. This is _probably_ an oversight, given that almost any player can opt for the Lesser Bloodsucker virtue.
