### PR TITLE
Adds a preference toggle to autoEat

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -132,7 +132,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/anonymize = TRUE
 	var/masked_examine = FALSE
 	var/mute_animal_emotes = FALSE
-	var/autoconsume = FALSE
+	var/autoconsume = TRUE
 
 	var/lastclass
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -132,6 +132,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/anonymize = TRUE
 	var/masked_examine = FALSE
 	var/mute_animal_emotes = FALSE
+	var/autoconsume = FALSE
 
 	var/lastclass
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -169,6 +169,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["anonymize"]			>> anonymize
 	S["masked_examine"]		>> masked_examine
 	S["mute_animal_emotes"]	>> mute_animal_emotes
+	S["autoconsume"]		>> autoconsume
 	S["crt"]				>> crt
 	S["grain"]				>> grain
 	S["sexable"]			>> sexable
@@ -263,6 +264,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["anonymize"], anonymize)
 	WRITE_FILE(S["masked_examine"], masked_examine)
 	WRITE_FILE(S["mute_animal_emotes"], mute_animal_emotes)
+	WRITE_FILE(S["autoconsume"], autoconsume)
 	WRITE_FILE(S["crt"], crt)
 	WRITE_FILE(S["sexable"], sexable)
 	WRITE_FILE(S["shake"], shake)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -71,6 +71,17 @@
 		else
 			to_chat(src, "You will now hear animal sound emotes.")
 
+/client/verb/autoconsume()
+	set category = "Options"
+	set name = "Toggle AutoConsume"
+	if(prefs)
+		prefs.autoconsume = !prefs.autoconsume
+		prefs.save_preferences()
+		if(prefs.autoconsume)
+			to_chat(src, "You will now try to repeatedly consume/feed food/drinks")
+		else
+			to_chat(src, "You will no longer try to repeatedly consume/feed food/drinks")
+
 /client/verb/toggle_ERP() // Alters if other people can use the ERP panel ON you.
 	set category = "Options"
 	set name = "Toggle ERP Panel"

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -404,7 +404,7 @@ All foods are distributed among various categories. Use common sense.
 				checkLiked(fraction, M)
 				if(bitecount >= bitesize)
 					qdel(src)
-				else
+				else if(user.client?.prefs.autoconsume)
 					if(M == user && do_after(user, CLICK_CD_MELEE))
 						INVOKE_ASYNC(src, PROC_REF(attack), M, user, def_zone)
 						user.changeNext_move(CLICK_CD_MELEE)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -76,13 +76,14 @@
 			to_chat(user, span_notice("I swallow a gulp of [src]."))
 		addtimer(CALLBACK(reagents, TYPE_PROC_REF(/datum/reagents, trans_to), M, min(amount_per_transfer_from_this,5), TRUE, TRUE, FALSE, user, FALSE, INGEST), 5)
 		playsound(M.loc,pick(drinksounds), 100, TRUE)
-	if(M == user && do_after(user, CLICK_CD_MELEE))
-		INVOKE_ASYNC(src, PROC_REF(attack), M, user, target)
-		user.changeNext_move(CLICK_CD_MELEE)
-	else if(M != user)
-		INVOKE_ASYNC(src, PROC_REF(attack), M, user, target)
-		user.changeNext_move(CLICK_CD_MELEE)
-	return
+		if(user.client?.prefs.autoconsume)
+			if(M == user && do_after(user, CLICK_CD_MELEE))
+				INVOKE_ASYNC(src, PROC_REF(attack), M, user, target)
+				user.changeNext_move(CLICK_CD_MELEE)
+			else if(M != user)
+				INVOKE_ASYNC(src, PROC_REF(attack), M, user, target)
+				user.changeNext_move(CLICK_CD_MELEE)
+		return
 
 /obj/item/reagent_containers/glass/attack_obj(obj/target, mob/living/user)
 	if(user.used_intent.type == INTENT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

There is now a toggle in preferences called Toggle Autoconsume that toggles if you will eat food once or continously. It defaults to ON to keep prior behauvior

## Testing Evidence

Opened up the game and tested eating with the toggle on and off.
Deleted the Preference file locally to make sure it does default to on

## Why It's Good For The Game

Lets people choose if they want to consume fast or if they want to roleplay eating/drinking slower