### PR TITLE
bloodsucker tweaks

### DIFF
--- a/code/modules/antagonists/roguetown/villain/bloodsucker.dm
+++ b/code/modules/antagonists/roguetown/villain/bloodsucker.dm
@@ -64,7 +64,7 @@
 
 	if(owner.special_role == "bloodsucker")
 		new_bloodsucker = FALSE
-	if(owner.special_role == "ancient bloodsucker")
+	if(owner.special_role == "Ancient Bloodsucker")
 		ancient_bloodsucker = TRUE
 
 	for(var/inherited_trait in inherent_traits)
@@ -72,7 +72,7 @@
 		ADD_TRAIT(owner.current, inherited_trait, TRAIT_GENERIC)
 
 	owner.current.cmode_music = 'sound/music/combat_vamp2.ogg'
-	owner.adjust_skillrank(/datum/skill/magic/vampirism, 1, TRUE)
+	owner.adjust_skillrank(/datum/skill/magic/vampirism, 6, TRUE)
 	owner.adjust_skillrank(/datum/skill/magic/blood, 1, TRUE)
 	if(!new_bloodsucker)
 		owner.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
@@ -89,6 +89,7 @@
 		owner.current.AddSpell(new /obj/effect/proc_holder/spell/invoked/recruitthrall)
 		owner.current.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/vampire_bat)
 		owner.current.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/vampire_mistform)
+		owner.current.AddSpell(new /obj/effect/proc_holder/spell/invoked/vampire_greaterregenerate)
 
 	if (new_bloodsucker)
 		//we give fewer points to new spawn or those with a virtue

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -520,7 +520,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		var/mob/living/carbon/human/devotee = user
 		devotee.devotion?.update_devotion(-devotion_cost)
 		to_chat(devotee, "<font color='purple'>I [devotion_cost > 0 ? "lost" : "gained"] [abs(devotion_cost)] devotion.</font>")
-	if(xp_gain && user.mind.get_skill_level(associated_skill) > 0) //We check the spell gives XP AND that the user has at least 1 level.
+	if(xp_gain && user.mind?.get_skill_level(associated_skill) > 0) //We check the spell gives XP AND that the user has at least 1 level.
 		add_sleep_experience(usr, associated_skill, round(get_fatigue_drain() * MAGIC_XP_MULTIPLIER))
 	if(!ignore_fiendkiss && HAS_TRAIT(user, TRAIT_FIENDKISS))
 		sleep(0.5 SECONDS)

--- a/code/modules/spells/spell_types/blood/learnvampspell.dm
+++ b/code/modules/spells/spell_types/blood/learnvampspell.dm
@@ -18,7 +18,7 @@
 	var/list/choices = list()
 	var/list/vamp_choices = list()
 
-	if(BSdrinker.bs_spawn == 1)
+	if(BSdrinker?.bs_spawn == 1)
 		//lesser perk list since they are fledglings
 		vamp_choices  += GLOB.learnable_fledgling_perks
 		//lesser spell list since they are fledglings

--- a/code/modules/spells/spell_types/blood/learnvampspell.dm
+++ b/code/modules/spells/spell_types/blood/learnvampspell.dm
@@ -96,8 +96,6 @@
 
 		//Heal limiters, we only allow one trait or spell to heal
 		if (HAS_TRAIT(user,TRAIT_VAMP_HEAL_LIMIT) && (item.name in list("Passive Regeneration", 
-																		"Bat Form", 
-																		"Mist Form", 
 																		"Vampiric Regeneration",)))
 			to_chat(user,span_warning("You have an ability to heal with already"))
 			return	//we can't give users more than one way to heal

--- a/code/modules/spells/spell_types/blood/utility/vampire_batform.dm
+++ b/code/modules/spells/spell_types/blood/utility/vampire_batform.dm
@@ -21,15 +21,15 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/blood
 	goodtrait = null //is there a good trait we want to associate? the code name
-	badtrait = TRAIT_VAMP_HEAL_LIMIT //is there a bad trait we want to associate? the code name
-	badtraitname = "Healing Abilities Limit" //is there a bad trait we want to associate? the player name
-	badtraitdesc = "You can only have one ability that gives a heal. Affects regeneration, passive regeneration, batform, and mistform" //is there a bad trait we want to associate? the player description
-	recharge_time = 10 MINUTES
+	badtrait = null //TRAIT_VAMP_HEAL_LIMIT //is there a bad trait we want to associate? the code name
+	badtraitname = null //"Healing Abilities Limit" //is there a bad trait we want to associate? the player name
+	badtraitdesc = null //"You can only have one ability that gives a heal. Affects regeneration, passive regeneration, batform, and mistform" //is there a bad trait we want to associate? the player description
+	recharge_time = 1 MINUTES
 	glow_color = GLOW_COLOR_VAMPIRIC
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 	vitaedrain = 100
 
-
+/*
 /obj/effect/proc_holder/spell/targeted/shapeshift/vampire_bat/cast(list/targets, mob/living/user = usr)
 	var/mob/living/carbon/human/H = usr
 	//var/temp_vitae = H.vitae //use this to store vitae if we need a dynamic cost
@@ -56,3 +56,4 @@
 	//need to find a simple way to change to a bat
 	to_chat(H, span_greentext("! FORM OF BAT !"))
 	H.playsound_local(get_turf(H), 'sound/misc/vampirespell.ogg', 100, FALSE, pressure_affected = FALSE)
+*/

--- a/code/modules/spells/spell_types/blood/utility/vampire_greaterregenerate.dm
+++ b/code/modules/spells/spell_types/blood/utility/vampire_greaterregenerate.dm
@@ -1,6 +1,6 @@
-/obj/effect/proc_holder/spell/invoked/vampire_regenerate
-	name = "Vampiric Regeneration"
-	desc = "Regenerate and heal my body"
+/obj/effect/proc_holder/spell/invoked/vampire_greaterregenerate
+	name = "Greater Vampiric Regeneration"
+	desc = "Regenerate using half of my blood (300 used minimum)"
 	cost = 2 //how many points it takes
 	xp_gain = TRUE
 	releasedrain = 0
@@ -20,69 +20,12 @@
 	badtrait = TRAIT_VAMP_HEAL_LIMIT //is there a bad trait we want to associate? the code name
 	badtraitname = "Healing Abilities Limit" //is there a bad trait we want to associate? the player name
 	badtraitdesc = "You can only have one ability that gives a heal. Affects regeneration, passive regeneration, batform, and mistform" //is there a bad trait we want to associate? the player description
-	recharge_time = 30 SECONDS
+	recharge_time = 3 MINUTES
 	glow_color = GLOW_COLOR_VAMPIRIC
 	glow_intensity = GLOW_INTENSITY_MEDIUM
-	vitaedrain = 75
+	vitaedrain = 300
 
-/obj/effect/proc_holder/spell/invoked/vampire_regenerate/cast(list/targets, mob/living/user)
-	. = ..()
-	if (!isliving(targets[1]))
-		revert_cast()
-		return FALSE
-	var/mob/living/carbon/human/BSDrinker = user
-	var/silver_curse_status = FALSE
-	//var/temp_vitae = BSDrinker.vitae
-	silver_curse_status = BSDrinker.has_status_effect(/datum/status_effect/debuff/silver_curse)
-	if(!BSDrinker == user)
-		recharge_time = 1 SECONDS
-		to_chat(BSDrinker, span_warning("I can only regenerate myself"))
-		return
-	if(silver_curse_status)
-		to_chat(BSDrinker, span_warning("My BANE is not letting me heal!"))
-		return
-	if(!HAS_TRAIT(BSDrinker,TRAIT_VAMPIRISM))
-		to_chat(BSDrinker, span_warning("I'm not a vampire, what am I doing?"))
-		return
-	if(BSDrinker.has_status_effect(/datum/status_effect/debuff/veil_up))
-		to_chat(BSDrinker, span_warning("My curse is hidden."))
-		return
-	if(BSDrinker.vitae < 75)
-		to_chat(BSDrinker, span_warning("Not enough vitae."))
-		return
-
-
-	//var/mob/living/target = targets[1]
-	//BSDrinker.visible_message(span_info("[BSDrinker] [othernotification]"), span_notice(targetnotification))
-
-	var/healing = 2.5 // Flat value, no patron bonuses like lesser_heal
-
-	//the cost of healing
-	BSDrinker.vitae -= vitaedrain
-
-	if (ishuman(BSDrinker))
-		//var/mob/living/carbon/human/H = target
-		var/no_embeds = TRUE
-		var/list/embeds = BSDrinker.get_embedded_objects()
-		if (length(embeds))
-			for (var/object in embeds)
-				if (!istype(object, /obj/item/natural/worms/leech))
-					no_embeds = FALSE
-					break
-		if (no_embeds)
-			BSDrinker.apply_status_effect(/datum/status_effect/buff/healing, healing)
-		else
-			BSDrinker.visible_message(span_warning("[BSDrinker]'s wounds tear and rip around embedded objects!"),
-			                       span_warning("Agonising pain shoots through your blood tries to close your wounds!"))
-			BSDrinker.adjustBruteLoss(20)
-			playsound(BSDrinker, 'sound/combat/dismemberment/dismem (2).ogg', 100)
-			BSDrinker.emote("agony")
-	else
-		// fallback for non-human living mobs
-		BSDrinker.apply_status_effect(/datum/status_effect/buff/healing, healing)
-	return TRUE
-
-/*
+/obj/effect/proc_holder/spell/invoked/vampire_greaterregenerate/cast(list/targets, mob/living/user)
 	if(isliving(user))
 		var/mob/living/carbon/human/BSDrinker = user
 		var/silver_curse_status = FALSE
@@ -114,10 +57,6 @@
 		BSDrinker.vitae -= vitaedrain
 		to_chat(BSDrinker, span_greentext("! REGENERATE !"))
 		BSDrinker.playsound_local(get_turf(BSDrinker), 'sound/misc/vampirespell.ogg', 100, FALSE, pressure_affected = FALSE)
-*/
-
-
-
 /* we can apply a buff and a glow if we want to telegraph this
 #define VAMPIRIC_FILTER "vampiric_glow"
 

--- a/code/modules/spells/spell_types/blood/utility/vampire_mistform.dm
+++ b/code/modules/spells/spell_types/blood/utility/vampire_mistform.dm
@@ -20,18 +20,18 @@
 	charging_slowdown = 60
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/blood
-	recharge_time = 10 MINUTES
+	recharge_time = 1 MINUTES
 	glow_color = GLOW_COLOR_VAMPIRIC
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 	vitaedrain = 100
 	xp_gain = TRUE
 	goodtrait = null //is there a good trait we want to associate? the code name
-	badtrait = TRAIT_VAMP_HEAL_LIMIT //is there a bad trait we want to associate? the code name
-	badtraitname = "Healing Abilities Limit" //is there a bad trait we want to associate? the player name
-	badtraitdesc = "You can only have one ability that gives a heal. Affects regeneration, passive regeneration, batform, and mistform" //is there a bad trait we want to associate? the player description
+	badtrait = null //TRAIT_VAMP_HEAL_LIMIT //is there a bad trait we want to associate? the code name
+	badtraitname = null //"Healing Abilities Limit" //is there a bad trait we want to associate? the player name
+	badtraitdesc = null //"You can only have one ability that gives a heal. Affects regeneration, passive regeneration, batform, and mistform" //is there a bad trait we want to associate? the player description
 
 
-
+/*
 /obj/effect/proc_holder/spell/targeted/shapeshift/vampire_mistform/cast(list/targets, mob/living/user = usr)
 	var/mob/living/carbon/human/BSDrinker = usr
 	//var/temp_vitae = H.vitae //use this to store vitae if we need a dynamic cost
@@ -60,3 +60,4 @@
 	//ADD_TRAIT(src, TRAIT_NOFALLDAMAGE2, MAGIC_TRAIT)
 	to_chat(BSDrinker, span_warning("mistform"))
 	addtimer(CALLBACK(BSDrinker, to_chat(BSDrinker, span_warning("I'm about to change back"))), 25 SECONDS)
+*/

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -32,13 +32,18 @@
 		if(VD.disguised)
 			to_chat(usr, span_warning("My curse is hidden."))
 			return
-	if(H.has_status_effect(/datum/status_effect/debuff/veil_up))
-		to_chat(usr, span_warning("My curse is hidden."))
-		return
-	if(HAS_TRAIT(H,TRAIT_VAMPIRISM) && (H.vitae < 100)) 
-		to_chat(src, span_warning("Not enough vitae blood."))
-		return
 	if(HAS_TRAIT(H,TRAIT_VAMPIRISM))
+		if(H.has_status_effect(/datum/status_effect/debuff/veil_up))
+			to_chat(H, span_warning("My curse is hidden."))
+			return
+		if(H.vitae < 100)
+			to_chat(H, span_warning("Not enough vitae."))
+			return
+		if(H.has_status_effect(/datum/status_effect/buff/vampire_bat))
+			to_chat(H, span_warning("Already active."))
+			return
+		to_chat(H, span_greentext("! SHAPESHIFT !"))
+		H.playsound_local(get_turf(H), 'sound/misc/vampirespell.ogg', 100, FALSE, pressure_affected = FALSE)
 		H.vitae -= 100
 	if(src in user.mob_spell_list)
 		user.mob_spell_list.Remove(src)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1984,6 +1984,7 @@
 #include "code\modules\spells\spell_types\blood\utility\vampire_float.dm"
 #include "code\modules\spells\spell_types\blood\utility\vampire_mistform.dm"
 #include "code\modules\spells\spell_types\blood\utility\vampire_regenerate.dm"
+#include "code\modules\spells\spell_types\blood\utility\vampire_greaterregenerate.dm"
 #include "code\modules\spells\spell_types\warlock\buffs_debuffs\cloak_of_flies.dm"
 #include "code\modules\spells\spell_types\warlock\buffs_debuffs\eldritch_curse.dm"
 #include "code\modules\spells\spell_types\warlock\buffs_debuffs\mischevious_whispers.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes the bugs that prevented shapeshiting

Allows for bloodsuckers to transform and heal now, but using batform or mistform will lock you into it for a minute. note that you no longer heal from 

Changed the regeneration spell to be a bit more like a warlock heal for 75 vitae and a 30 second cooldown, while a greater regeneration spell will fully heal while taking half your Vitae OR 300 on a 3 minute cooldown. you still can't get passive regen with the active regen, to help balance things.

## Testing Evidence

tested in game and verified, but would like this test merged and tried out to make sure the values aren't too low. 

## Why It's Good For The Game

allows for more options for bloodsuckers
