### PR TITLE
Colored Text

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -456,6 +456,17 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 	// Escape  single characters that will be used
 
 	t = replacetext(t, "!", "$a")
+	
+	// Parse colour
+	if(!barebones)
+		var/regex/hexgex = regex(@"(?<=-=)(.{6})", "g")
+		while(hexgex.Find(t))
+			var/endblock = findtext(t, "=-", hexgex.index)
+			if(!endblock)
+				break
+			t = replacetext(t, "=-", "</font>", hexgex.index, endblock+2)
+			var/c_code = sanitize_hexcolor(hexgex.match)
+			t = replacetext(t, "-=[hexgex.match]", "<font color='[c_code]'>", hexgex.index-2, endblock+2)
 
 	// Parse hr and small
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1608,7 +1608,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					dat += "^text^ : Increases the <font size = \"4\">size</font> of the text.<br>"
 					dat += "((text)) : Decreases the <font size = \"1\">size</font> of the text.<br>"
 					dat += "* item : An unordered list item.<br>"
-					dat += "--- : Adds a horizontal rule.<br><br>"
+					dat += "--- : Adds a horizontal rule.<br>"
+					dat += "-=FFFFFFtext=- : Adds a specific <font color = '#FFFFFF'>colour</font> to text.<br><br>"
 					dat += "Minimum Flavortext: <b>[MINIMUM_FLAVOR_TEXT]</b> characters.<br>"
 					dat += "Minimum OOC Notes: <b>[MINIMUM_OOC_NOTES]</b> characters."
 					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 350)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -324,7 +324,8 @@
 		((text)) : Decreases the <font size = \"1\">size</font> of the text.<br>
 		* item : An unordered list item.<br>
 		&nbsp;&nbsp;* item: An unordered list child item.<br>
-		--- : Adds a horizontal rule.
+		--- : Adds a horizontal rule.<br>
+		-=FFFFFFtext=- : Adds a specific <font color = '#FFFFFF'>colour</font> to text.
 	</BODY></HTML>"}, "window=paper_help")
 
 


### PR DESCRIPTION
## About The Pull Request

Colored text markers for profiles and paper

from the AP port:
custom color on paperwork: https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2562

## Testing Evidence

Here's it being added into a profile
<img width="355" height="296" alt="image" src="https://github.com/user-attachments/assets/04db51b0-ec29-4c8a-b34c-d2e6f74970cc" />
<img width="457" height="215" alt="image" src="https://github.com/user-attachments/assets/7cac6997-ac07-4da9-9cbc-1bd2be1c7fef" />

and onto some paper
<img width="353" height="301" alt="image" src="https://github.com/user-attachments/assets/353a1531-53f1-4898-9370-14503cb62e48" />
<img width="426" height="220" alt="image" src="https://github.com/user-attachments/assets/7161db31-a68f-4cb0-acf6-1454064da93c" />


## Why It's Good For The Game

more colorful options for players and books.
