### PR TITLE
Headshot in chat option

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1,3 +1,4 @@
+
 GLOBAL_LIST_EMPTY(preferences_datums)
 
 GLOBAL_LIST_EMPTY(chosen_names)
@@ -161,6 +162,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/update_mutant_colors = TRUE
 
 	var/headshot_link
+	var/chatheadshot
 	var/ooc_extra_link
 	var/ooc_extra
 	var/list/descriptor_entries = list()
@@ -441,7 +443,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 				dat += "<br><img src='[headshot_link]' width='100px' height='100px'>"
 			if(is_legacy)
 				dat += "<br><i><font size = 1>(Legacy)<a href='?_src_=prefs;preference=legacyhelp;task=input'>(?)</a></font></i>"
-
+			dat += "<br><b>Headshots in chat?:</b> <a href='?_src_=prefs;preference=headshotchat;task=input'>[chatheadshot == 2 ? "Yes" : "No"]</a><a href='?_src_=prefs;preference=chatheadshothelp;task=input'>(?)</a>"
+			
 			dat += "<br><b>[(length(flavortext) < MINIMUM_FLAVOR_TEXT) ? "<font color = '#802929'>" : ""]Flavortext:[(length(flavortext) < MINIMUM_FLAVOR_TEXT) ? "</font>" : ""]</b><a href='?_src_=prefs;preference=formathelp;task=input'>(?)</a><a href='?_src_=prefs;preference=flavortext;task=input'>Change</a>"
 
 			dat += "<br><b>[(length(ooc_notes) < MINIMUM_OOC_NOTES) ? "<font color = '#802929'>" : ""]OOC Notes:[(length(ooc_notes) < MINIMUM_OOC_NOTES) ? "</font>" : ""]</b><a href='?_src_=prefs;preference=formathelp;task=input'>(?)</a><a href='?_src_=prefs;preference=ooc_notes;task=input'>Change</a>"
@@ -1585,7 +1588,11 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					headshot_link = new_headshot_link
 					to_chat(user, "<span class='notice'>Successfully updated headshot picture</span>")
 					log_game("[user] has set their Headshot image to '[headshot_link]'.")
-
+				if("headshotchat")
+					if(chatheadshot == 1)
+						chatheadshot = 2
+					else
+						chatheadshot = 1
 				if("legacyhelp")
 					var/list/dat = list()
 					dat += "This slot was around since before major Flavortext / OOC changes.<br>"
@@ -1612,6 +1619,12 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					dat += "-=FFFFFFtext=- : Adds a specific <font color = '#FFFFFF'>colour</font> to text.<br><br>"
 					dat += "Minimum Flavortext: <b>[MINIMUM_FLAVOR_TEXT]</b> characters.<br>"
 					dat += "Minimum OOC Notes: <b>[MINIMUM_OOC_NOTES]</b> characters."
+					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 350)
+					popup.set_content(dat.Join())
+					popup.open(FALSE)
+				if("chatheadshothelp")
+					var/list/dat = list()
+					dat +="Click this option to make other's headshots appear in chat<br>"
 					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 350)
 					popup.set_content(dat.Join())
 					popup.open(FALSE)
@@ -2381,6 +2394,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 	character.dna.real_name = character.real_name
 
 	character.headshot_link = headshot_link
+
+	character.chatheadshot = chatheadshot
 
 	character.statpack = statpack
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -506,7 +506,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["headshot_link"]			>> headshot_link
 	if(!valid_headshot_link(null, headshot_link, TRUE))
 		headshot_link = null
-
+	S["chatheadshot"]		>> chatheadshot
 	S["flavortext"]			>> flavortext
 	S["flavortext_display"]	>> flavortext_display
 	S["ooc_notes"]			>> ooc_notes
@@ -660,6 +660,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	WRITE_FILE(S["update_mutant_colors"] , update_mutant_colors)
 	WRITE_FILE(S["headshot_link"] , headshot_link)
+	WRITE_FILE(S["chatheadshot"] , chatheadshot)
 	WRITE_FILE(S["flavortext"] , html_decode(flavortext))
 	WRITE_FILE(S["flavortext_display"], flavortext_display)
 	WRITE_FILE(S["ooc_notes"] , html_decode(ooc_notes))

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -20,6 +20,7 @@
 	ooc_extra_link = null
 	ooc_extra = null
 	headshot_link = null
+	chatheadshot = 1
 	features = pref_species.get_random_features()
 	body_markings = pref_species.get_random_body_markings(features)
 	accessory = "Nothing"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -27,6 +27,7 @@
 	var/t_is = p_are()
 	var/obscure_name = FALSE
 	var/race_name = dna.species.name
+	var/mob/living/carbon/human/viewer = user
 	var/datum/antagonist/maniac/maniac = user.mind?.has_antag_datum(/datum/antagonist/maniac)
 	if(maniac && (user != src))
 		race_name = "disgusting pig"
@@ -725,6 +726,11 @@
 		if(heart?.inscryption && (heart.inscryption_key in maniac.key_nums))
 			. += span_danger("[t_He] know[p_s()] [heart.inscryption_key], I AM SURE OF IT!")
 
+	if((!obscure_name || client?.prefs.masked_examine) && (flavortext || headshot_link || ooc_notes) && (viewer?.chatheadshot == 2))
+		if((HAS_TRAIT(user,TRAIT_VAMPIRISM)) && (has_status_effect(/datum/status_effect/buff/veil_down)) && (valid_headshot_link(null, antag_headshot_link, TRUE)))
+			. += "<span class='info'><img src=[antag_headshot_link] width=100 height=100/></span>"
+		else if(headshot_link)
+			. += "<span class='info'><img src=[headshot_link] width=100 height=100/></span>"
 	if(Adjacent(user))
 		if(observer_privilege)
 			var/static/list/check_zones = list(

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -107,6 +107,7 @@
 	var/datum/devotion/devotion = null // Used for cleric_holder for priests
 
 	var/headshot_link = null
+	var/chatheadshot = null
 	var/flavortext = null
 	var/flavortext_display = null
 	var/ooc_notes = null


### PR DESCRIPTION
## About The Pull Request

Took some inspiration from dreamkeep/helmsguard and added a 100x100 headshot if you have one loaded. will also pull in a bloodsucker headshot if they have it loaded and their veil is down. Will not show if your hood is up

## Testing Evidence

showing the standard headshot
<img width="361" height="452" alt="image" src="https://github.com/user-attachments/assets/07816486-8b21-4aac-b2f5-47cb34dd39d1" />
Showing the option toggle in preferences
<img width="180" height="113" alt="image" src="https://github.com/user-attachments/assets/fc9a1e7f-28f2-4e34-bc0c-95b2de623299" />

Showing self with the option set to "no"
<img width="462" height="414" alt="image" src="https://github.com/user-attachments/assets/d698a813-f53e-4354-8a97-f4df2746522d" />
<img width="389" height="382" alt="image" src="https://github.com/user-attachments/assets/256d8595-7bf0-4fe3-9544-c963aec7a1c2" />

Other character has it on
<img width="418" height="468" alt="image" src="https://github.com/user-attachments/assets/94cad4f9-4eaa-4a56-b529-702353b07b80" />

Showing it with veil up and veil down
<img width="302" height="602" alt="image" src="https://github.com/user-attachments/assets/66cd9cee-e218-4470-a351-58ce0148ce53" />

showing how you can see the headshot but nothing with a hood up.
<img width="373" height="582" alt="image" src="https://github.com/user-attachments/assets/4943509d-e06f-46df-82e1-784058596f48" />


## Why It's Good For The Game

Gives a quick look option for someone with a headshot without having to examine them.  This should help folks identify others quickly to recognize them. This is not intended to pressure folks to have a headshot loaded, however. 
