### PR TITLE
Revert "Nobleman RCP drop"

### DIFF
--- a/code/modules/jobs/job_types/roguetown/keep/nobility/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/keep/nobility/noble.dm
@@ -18,7 +18,7 @@
 	noble_income = 20
 	min_pq = 1
 	max_pq = null
-	round_contrib_points = 1
+	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'
 
 /datum/job/roguetown/nobleman/after_spawn(mob/living/L, mob/M, latejoin)


### PR DESCRIPTION
Reverts NovaSector/Solaris#360

This PR is to revert the Noble RCP drop with the rationale below. 

Reducing RCP for nobles feels more like a punishment to the players who may enjoy the role rather than anything legitimate that will force people to play other roles. 3 RCP would still require a good chunk of rounds to equate to 1 PQ (Should be 4 if the ratio of RCP to PQ is still  10 to 1.  THat effectively makes it from 4 rounds to 10, effectively doubling it for what is already a very small amount of PQ, especially when RCP does have a cap out limit too.  In rounds that do have population and no Marquis present, that does make them one of the prospective leaders until the position is filled. 1 RCP sets it lower than any other possible role available for no solid grounded reason that can be said enhances the experience, nor would this incentivize people to bloom out to other roles if it is outside of their preferences, or what realistically would be something an established character would already do.  If RCP was the main incentive for playing a role, bandits would be occupied heavily due to the 5 RCP given each round. 